### PR TITLE
Add support for more join/leave command formats

### DIFF
--- a/EventHandlers/JoinOptinGuildHandler.cs
+++ b/EventHandlers/JoinOptinGuildHandler.cs
@@ -30,12 +30,15 @@ namespace Reiati.ChillBot.EventHandlers
 
         /// <summary>
         /// The matcher for detecting the phrases:
-        /// - <@123> join {1}
-        /// - <@123> join #{1}
-        /// And captures the proposed channel name into group 1
+        /// - <@123> join {channel}
+        /// - <@123> join #{channel}
+        /// - <@123> join opt-in {channel}
+        /// - <@123> join opt in {channel}
+        /// - <@123> join optin {channel}
+        /// And captures the proposed channel name into the named capture group "channel"
         /// </summary>
         private static Regex matcher = new Regex(
-            @"^\s*\<\@\!?\d+\>\s*join\s+#?(\S+)$",
+            @"^\s*\<\@\!?\d+\>\s*join(\s+opt(?:-|\s)?in)?\s+#?(?<channel>\S+)$",
             RegexOptions.IgnoreCase,
             HardCoded.Handlers.DefaultRegexTimeout);
 
@@ -62,7 +65,7 @@ namespace Reiati.ChillBot.EventHandlers
             var messageChannel = message.Channel as SocketGuildChannel;
             var author = message.Author as SocketGuildUser;
             var guildConnection = messageChannel.Guild;
-            var channelName = handleCache.Groups[1].Captures[0].Value;
+            var channelName = handleCache.Groups["channel"].Captures[0].Value;
 
             var checkoutResult = checkoutResultPool.Get();
             try

--- a/EventHandlers/LeaveOptinDmHandler.cs
+++ b/EventHandlers/LeaveOptinDmHandler.cs
@@ -40,10 +40,11 @@ namespace Reiati.ChillBot.EventHandlers
         /// - leave opt-in #{1}
         /// - leave optin {1}
         /// - leave opt in {1}
-        /// And captures the proposed channel name into group 1
+        /// - <@123> leave opt-in #{1}
+        /// And captures the proposed channel name into the named capture group "channel"
         /// </summary>
         private static Regex matcher = new Regex(
-            @"^\s*leave\s+opt(?:-|\s)?in\s+#?(\S+)$",
+            @"^\s*(\<\@\!?\d+\>\s*)?leave\s+opt(?:-|\s)?in\s+#?(?<channel>\S+)$",
             RegexOptions.IgnoreCase,
             HardCoded.Handlers.DefaultRegexTimeout);
 
@@ -80,7 +81,7 @@ namespace Reiati.ChillBot.EventHandlers
 
             var guildConnection = mutualGuilds.Single();//this.discordClient.GetGuild(mutualGuilds.Single().Value);
             var requestAuthor = guildConnection.GetUser(author.Id);
-            var channelName = handleCache.Groups[1].Captures[0].Value;
+            var channelName = handleCache.Groups["channel"].Captures[0].Value;
 
             var checkoutResult = checkoutResultPool.Get();
             try


### PR DESCRIPTION
Add support for the following additional opt-in command syntaxes:
- Joining opt-ins with the word "opt-in" included in the command
- Leaving opt-ins with a user mention at the beginning of the command

Switch to using [Named Matched Subexpressions](https://docs.microsoft.com/dotnet/standard/base-types/grouping-constructs-in-regular-expressions#named-matched-subexpressions) to extract the channel name from the command rather than relying on the quantity and order of capture groups.