### PR TITLE
Add support for Azure Blob Storage as a guild repository type

### DIFF
--- a/ChillBot.csproj
+++ b/ChillBot.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
     <PackageReference Include="Discord.Net" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.17.0" />

--- a/Data/AzureBlobGuildRepository.cs
+++ b/Data/AzureBlobGuildRepository.cs
@@ -1,0 +1,160 @@
+﻿using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Reiati.ChillBot.Tools;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Reiati.ChillBot.Data
+{
+    /// <summary>
+    /// A repository of <see cref="Guild"/> objects to be checked out and checked in from Azure Blob storage.
+    /// </summary>
+    public class AzureBlobGuildRepository : IGuildRepository
+    {
+        /// <summary>
+        /// The HTTP status code returned when a blob is not found.
+        /// </summary>
+        private const int NotFoundStatus = 404;
+
+        /// <summary>
+        /// The HTTP status code returned when there is a conflict.
+        /// </summary>
+        private const int ConflictStatus = 409;
+
+        /// <summary>
+        /// The maximum amount of time to lease a guild blob when it is checked out.
+        /// </summary>
+        /// <remarks>
+        /// If the guild blob is not returned within this time period, the lease will expire.
+        /// </remarks>
+        private static readonly TimeSpan BlobLeaseDuration = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// The client to access the container in Blob storage
+        /// </summary>
+        private BlobContainerClient blobContainerClient;
+
+        /// <summary>
+        /// Constructs a <see cref="AzureBlobGuildRepository"/>.
+        /// </summary>
+        public AzureBlobGuildRepository(string connectionString, string containerName)
+        {
+            ValidateArg.IsNotNullOrWhiteSpace(connectionString, nameof(connectionString));
+            ValidateArg.IsNotNullOrWhiteSpace(containerName, nameof(containerName));
+
+            this.blobContainerClient = new BlobContainerClient(connectionString, containerName);
+            var ignoreAwait = this.blobContainerClient.CreateIfNotExistsAsync();
+        }
+
+        /// <summary>
+        /// Checkout out a <see cref="Guild"/>.
+        /// </summary>
+        /// <param name="guildId">An id representing a guild.</param>
+        /// <param name="recycleResult">A preallocated result that should be returned if passed in.</param>
+        /// <returns>The borrowed guild.</returns>
+        public async Task<GuildCheckoutResult> Checkout(Snowflake guildId, GuildCheckoutResult recycleResult = null)
+        {
+            var retVal = recycleResult ?? new GuildCheckoutResult();
+
+            try
+            {
+                string blobName = AzureBlobGuildRepository.GetBlobName(guildId);
+                var blobClient = this.blobContainerClient.GetBlockBlobClient(blobName);
+
+                // Aquire a lease on the blob
+                var blobLeaseClient = blobClient.GetBlobLeaseClient();
+                var leaseResult = await blobLeaseClient.AcquireAsync(AzureBlobGuildRepository.BlobLeaseDuration).ConfigureAwait(false);
+                var lease = leaseResult.Value;
+
+                Guild guild;
+                using (var sourceStream = await blobClient.OpenReadAsync())
+                using (var streamReader = new StreamReader(sourceStream))
+                using (var jsonReader = new JsonTextReader(streamReader))
+                {
+                    guild = GuildConverter.FromJToken(guildId, await JObject.ReadFromAsync(jsonReader));
+                }
+
+                retVal.ToSuccess(new Borrowed<Guild>(
+                    isntance: guild,
+                    data: lease,
+                    onReturn: this.ReturnGuild));
+
+                return retVal;
+            }
+            catch (RequestFailedException e)
+            {
+                if (e.Status == AzureBlobGuildRepository.NotFoundStatus)
+                {
+                    retVal.ToDoesNotExist();
+                    return retVal;
+                }
+                else if (e.Status == AzureBlobGuildRepository.ConflictStatus && "LeaseAlreadyPresent".Equals(e.ErrorCode, StringComparison.OrdinalIgnoreCase))
+                {
+                    retVal.ToLocked();
+                    return retVal;
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The action invoked when a <see cref="Borrowed<T>"/> is being returned.
+        /// </summary>
+        /// <param name="guild">The guild that's being returned.</param>
+        /// <param name="data">
+        /// The object placed into the data field at the construction of the <see cref="Borrowed<T>"/>.
+        /// </param>
+        /// <param name="commit">
+        /// True if the user wanted to commit the changes, false if they wanted them discarded.
+        /// </param>
+        private void ReturnGuild(Guild guild, object data, bool commit)
+        {
+            string blobName = AzureBlobGuildRepository.GetBlobName(guild.Id);
+
+            var blobLease = (BlobLease)data;
+            var blobClient = this.blobContainerClient.GetBlockBlobClient(blobName);
+
+            // Get the lease client and populate the lease information in the request options
+            var blobLeaseClient = blobClient.GetBlobLeaseClient(blobLease.LeaseId);
+            var blobRequestConditions = new BlobRequestConditions() { LeaseId = blobLeaseClient.LeaseId };
+
+            if (commit)
+            {
+                JsonSerializer serializer = new JsonSerializer();
+#if DEBUG
+                serializer.Formatting = Formatting.Indented;
+#else
+                serializer.Formatting = Formatting.None;
+#endif
+
+                using (var stream = blobClient.OpenWrite(overwrite: true, new BlockBlobOpenWriteOptions() { OpenConditions = blobRequestConditions }))
+                using (var streamWriter = new StreamWriter(stream))
+                using (var writer = new JsonTextWriter(streamWriter))
+                {
+                    serializer.Serialize(writer, GuildConverter.ToJToken(guild));
+                }
+            }
+
+            // Release the lease on the blob
+            blobLeaseClient.Release();
+        }
+
+        /// <summary>
+        /// Returns the name of the blob that stores a Guild.
+        /// </summary>
+        /// <param name="guildId">An id representing a guild.</param>
+        /// <returns>The path to the file that stores a Guild.</returns>
+        private static string GetBlobName(Snowflake guildId)
+        {
+            return guildId + ".json";
+        }
+    }
+}

--- a/Data/FileBasedGuildRepository.cs
+++ b/Data/FileBasedGuildRepository.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -60,7 +59,7 @@ namespace Reiati.ChillBot.Data
 
                 var streamReader = new StreamReader(sourceStream);
                 var jsonReader = new JsonTextReader(streamReader);
-                var guild = FileBasedGuildRepository.FromJToken(guildId, await JObject.ReadFromAsync(jsonReader));
+                var guild = GuildConverter.FromJToken(guildId, await JObject.ReadFromAsync(jsonReader));
 
                 retVal.ToSuccess(new Borrowed<Guild>(
                     isntance: guild,
@@ -85,103 +84,6 @@ namespace Reiati.ChillBot.Data
                     throw;
                 }
             }
-        }
-
-        /// <summary>
-        /// Returns a Guild from a JToken.
-        /// </summary>
-        /// <param name="guildId">An id representing the guild.</param>
-        /// <param name="data">The JToken being read in.</param>
-        /// <returns>A guild from the data in the JToken.</returns>
-        private static Guild FromJToken(Snowflake guildId, JToken data)
-        {
-            JObject dataObj = data.ToObject<JObject>();
-            var retVal = new Guild(guildId);
-
-            if (dataObj.TryGetValue(SerializationFields.OptinCreatorsRoles, out JToken optinCreatorsRolesToken))
-            {
-                if (optinCreatorsRolesToken.Type != JTokenType.Array)
-                {
-                    throw new InvalidDataException(
-                        $"{SerializationFields.OptinCreatorsRoles} is expected to be an array type.");
-                }
-
-                var optinCreatorsRolesArray = optinCreatorsRolesToken.ToObject<JArray>();
-                foreach (var roleToken in optinCreatorsRolesArray)
-                {
-                    if (roleToken.Type != JTokenType.Integer)
-                    {
-                        throw new InvalidDataException(
-                            $"Each member of {SerializationFields.OptinCreatorsRoles} is expected to be an integer type.");
-                    }
-
-                    var roleId = new Snowflake(roleToken.ToObject<UInt64>());
-                    retVal.OptinCreatorsRoles.Add(roleId);
-                }
-            }
-
-            if (dataObj.TryGetValue(SerializationFields.OptinParentCatgory, out JToken optinParentCatgory))
-            {
-                if (optinParentCatgory.Type != JTokenType.Integer)
-                {
-                    throw new InvalidDataException(
-                        $"{SerializationFields.OptinCreatorsRoles} is expected to be an integer type.");
-                }
-
-                var categoryId = new Snowflake(optinParentCatgory.ToObject<UInt64>());
-                retVal.OptinParentCategory = categoryId;
-            }
-
-            if (dataObj.TryGetValue(SerializationFields.WelcomeChannel, out JToken welcomeChannel))
-            {
-                if (welcomeChannel.Type != JTokenType.Integer)
-                {
-                    throw new InvalidDataException(
-                        $"{SerializationFields.WelcomeChannel} is expected to be an integer type.");
-                }
-
-                var welcomeChannelId = new Snowflake(welcomeChannel.ToObject<UInt64>());
-                retVal.WelcomeChannel = welcomeChannelId;
-            }
-
-            return retVal;
-        }
-
-        /// <summary>
-        /// Returns a JToken representation of a given guild.
-        /// </summary>
-        /// <param name="guild">Any guild. May not be null.</param>
-        /// <returns>A JToken representation of a given guild.</returns>
-        private static JToken ToJToken(Guild guild)
-        {
-            JObject retVal = new JObject();
-
-            if (guild.OptinCreatorsRoles.Count > 0)
-            {
-                var optinCreatorsRolesArray = new JArray();
-                foreach (var roleId in guild.OptinCreatorsRoles)
-                {
-                    optinCreatorsRolesArray.Add(new JValue(roleId.Value));
-                }
-
-                retVal.Add(SerializationFields.OptinCreatorsRoles, optinCreatorsRolesArray);
-            }
-
-            if (guild.OptinParentCategory.HasValue)
-            {
-                retVal.Add(
-                    SerializationFields.OptinParentCatgory,
-                    new JValue(guild.OptinParentCategory.GetValueOrDefault().Value));
-            }
-
-            if (guild.WelcomeChannel.HasValue)
-            {
-                retVal.Add(
-                    SerializationFields.WelcomeChannel,
-                    new JValue(guild.WelcomeChannel.GetValueOrDefault().Value));
-            }
-
-            return retVal;
         }
 
         /// <summary>
@@ -212,7 +114,7 @@ namespace Reiati.ChillBot.Data
                 // TODO: In theory, we shouldn't need to copy to a string, and then serialize to file.
                 //   Figure out how to serialize directly to file.
                 var content = JsonConvert.SerializeObject(
-                    FileBasedGuildRepository.ToJToken(guild),
+                    GuildConverter.ToJToken(guild),
                     formatting);
 
                 var writer = new StreamWriter(sourceStream);
@@ -231,18 +133,6 @@ namespace Reiati.ChillBot.Data
         private static string GetFilePath(Snowflake guildId)
         {
             return Path.Combine(FileBasedGuildRepository.GuildsRepositoryPath, guildId + ".json");
-        }
-
-        /// <summary>
-        /// Collection of field names.
-        /// </summary>
-        private static class SerializationFields
-        {
-            // Implementer's note: no need to document fields.
-
-            public const string OptinCreatorsRoles = "OptinCreatorsRoles";
-            public const string OptinParentCatgory = "OptinParentCatgory";
-            public const string WelcomeChannel = "WelcomeChannel";
         }
     }
 }

--- a/Data/FileBasedGuildRepository.cs
+++ b/Data/FileBasedGuildRepository.cs
@@ -10,7 +10,7 @@ namespace Reiati.ChillBot.Data
     /// <summary>
     /// A repository of <see cref="Guild"/> objects to be checked out and checked in.
     /// </summary>
-    public class FileBasedGuildRepository
+    public class FileBasedGuildRepository : IGuildRepository
     {
         /// <summary>
         /// HRResult of the exception when the file is already in use.
@@ -44,9 +44,9 @@ namespace Reiati.ChillBot.Data
         /// <param name="guildId">An id representing a guild.</param>
         /// <param name="recycleResult">A preallocated result that should be returned if passed in.</param>
         /// <returns>The borrowed guild.</returns>
-        public async Task<CheckoutResult> Checkout(Snowflake guildId, CheckoutResult recycleResult = null)
+        public async Task<GuildCheckoutResult> Checkout(Snowflake guildId, GuildCheckoutResult recycleResult = null)
         {
-            var retVal = recycleResult ?? new CheckoutResult();
+            var retVal = recycleResult ?? new GuildCheckoutResult();
 
             try
             {
@@ -243,73 +243,6 @@ namespace Reiati.ChillBot.Data
             public const string OptinCreatorsRoles = "OptinCreatorsRoles";
             public const string OptinParentCatgory = "OptinParentCatgory";
             public const string WelcomeChannel = "WelcomeChannel";
-        }
-
-        /// <summary>
-        /// The result of a <see cref="FileBasedGuildRepository.Checkout(Snowflake)"/> call.
-        /// </summary>
-        /// <remarks>Designed to be poolable. Mimics the structure of a discriminated union.</remarks>
-        public sealed class CheckoutResult
-        {
-            /// <summary>
-            /// The type of this result.
-            /// </summary>
-            public ResultType Result { get; private set; }
-
-            /// <summary>
-            /// [<see cref="ResultType.Success"/>] The <see cref="Data.Guild"/> associated with the given id.
-            /// </summary>
-            public Borrowed<Guild> BorrowedGuild { get; private set; }
-
-            /// <summary>
-            /// Set this result to the <see cref="ResultType.Success"/> type.
-            /// </summary>
-            /// <param name="borrowedGuild">The borrowed guild to return.</param>
-            public void ToSuccess(Borrowed<Guild> borrowedGuild)
-            {
-                this.Result = ResultType.Success;
-                this.BorrowedGuild = borrowedGuild;
-            }
-
-            /// <summary>
-            /// Set this result to the <see cref="ResultType.DoesNotExist"/> type.
-            /// </summary>
-            public void ToDoesNotExist()
-            {
-                this.Result = ResultType.DoesNotExist;
-            }
-
-            /// <summary>
-            /// Set this result to the <see cref="ResultType.Locked"/> type.
-            /// </summary>
-            public void ToLocked()
-            {
-                this.Result = ResultType.Locked;
-            }
-
-            /// <summary>
-            /// Drops all references to objects.
-            /// </summary>
-            /// <remarks>Useful call before returning to a pool.</remarks>
-            public void ClearReferences()
-            {
-                this.BorrowedGuild = null;
-            }
-
-            /// <summary>
-            /// Result type of a <see cref="FileBasedGuildRepository.Checkout(Snowflake)"/> call.
-            /// </summary>
-            public enum ResultType
-            {
-                /// <summary>A <see cref="Data.Guild"/> was successfully checked out.</summary>
-                Success,
-
-                /// <summary>No guild was associated with the given guild id.</summary>
-                DoesNotExist,
-
-                /// <summary>This guild is currently in use, try again later.</summary>
-                Locked,
-            }
         }
     }
 }

--- a/Data/GuildCheckoutResult.cs
+++ b/Data/GuildCheckoutResult.cs
@@ -1,0 +1,69 @@
+﻿namespace Reiati.ChillBot.Data
+{
+    /// <summary>
+    /// The result of a <see cref="IGuildRepository.Checkout(Snowflake)"/> call.
+    /// </summary>
+    /// <remarks>Designed to be poolable. Mimics the structure of a discriminated union.</remarks>
+    public sealed class GuildCheckoutResult
+    {
+        /// <summary>
+        /// The type of this result.
+        /// </summary>
+        public ResultType Result { get; private set; }
+
+        /// <summary>
+        /// [<see cref="ResultType.Success"/>] The <see cref="Data.Guild"/> associated with the given id.
+        /// </summary>
+        public Borrowed<Guild> BorrowedGuild { get; private set; }
+
+        /// <summary>
+        /// Set this result to the <see cref="ResultType.Success"/> type.
+        /// </summary>
+        /// <param name="borrowedGuild">The borrowed guild to return.</param>
+        public void ToSuccess(Borrowed<Guild> borrowedGuild)
+        {
+            this.Result = ResultType.Success;
+            this.BorrowedGuild = borrowedGuild;
+        }
+
+        /// <summary>
+        /// Set this result to the <see cref="ResultType.DoesNotExist"/> type.
+        /// </summary>
+        public void ToDoesNotExist()
+        {
+            this.Result = ResultType.DoesNotExist;
+        }
+
+        /// <summary>
+        /// Set this result to the <see cref="ResultType.Locked"/> type.
+        /// </summary>
+        public void ToLocked()
+        {
+            this.Result = ResultType.Locked;
+        }
+
+        /// <summary>
+        /// Drops all references to objects.
+        /// </summary>
+        /// <remarks>Useful call before returning to a pool.</remarks>
+        public void ClearReferences()
+        {
+            this.BorrowedGuild = null;
+        }
+
+        /// <summary>
+        /// Result type of a <see cref="FileBasedGuildRepository.Checkout(Snowflake)"/> call.
+        /// </summary>
+        public enum ResultType
+        {
+            /// <summary>A <see cref="Data.Guild"/> was successfully checked out.</summary>
+            Success,
+
+            /// <summary>No guild was associated with the given guild id.</summary>
+            DoesNotExist,
+
+            /// <summary>This guild is currently in use, try again later.</summary>
+            Locked,
+        }
+    }
+}

--- a/Data/GuildConverter.cs
+++ b/Data/GuildConverter.cs
@@ -1,0 +1,122 @@
+﻿using Newtonsoft.Json.Linq;
+using Reiati.ChillBot.Tools;
+using System;
+using System.IO;
+
+namespace Reiati.ChillBot.Data
+{
+    /// <summary>
+    /// Class with helper methods for converting to/from <see cref="Guild"/> objects.
+    /// </summary>
+    public static class GuildConverter
+    {
+        /// <summary>
+        /// Returns a Guild from a JToken.
+        /// </summary>
+        /// <param name="guildId">An id representing the guild.</param>
+        /// <param name="data">The JToken being read in.</param>
+        /// <returns>A guild from the data in the JToken.</returns>
+        public static Guild FromJToken(Snowflake guildId, JToken data)
+        {
+            JObject dataObj = data.ToObject<JObject>();
+            var retVal = new Guild(guildId);
+
+            if (dataObj.TryGetValue(SerializationFields.OptinCreatorsRoles, out JToken optinCreatorsRolesToken))
+            {
+                if (optinCreatorsRolesToken.Type != JTokenType.Array)
+                {
+                    throw new InvalidDataException(
+                        $"{SerializationFields.OptinCreatorsRoles} is expected to be an array type.");
+                }
+
+                var optinCreatorsRolesArray = optinCreatorsRolesToken.ToObject<JArray>();
+                foreach (var roleToken in optinCreatorsRolesArray)
+                {
+                    if (roleToken.Type != JTokenType.Integer)
+                    {
+                        throw new InvalidDataException(
+                            $"Each member of {SerializationFields.OptinCreatorsRoles} is expected to be an integer type.");
+                    }
+
+                    var roleId = new Snowflake(roleToken.ToObject<UInt64>());
+                    retVal.OptinCreatorsRoles.Add(roleId);
+                }
+            }
+
+            if (dataObj.TryGetValue(SerializationFields.OptinParentCatgory, out JToken optinParentCatgory))
+            {
+                if (optinParentCatgory.Type != JTokenType.Integer)
+                {
+                    throw new InvalidDataException(
+                        $"{SerializationFields.OptinCreatorsRoles} is expected to be an integer type.");
+                }
+
+                var categoryId = new Snowflake(optinParentCatgory.ToObject<UInt64>());
+                retVal.OptinParentCategory = categoryId;
+            }
+
+            if (dataObj.TryGetValue(SerializationFields.WelcomeChannel, out JToken welcomeChannel))
+            {
+                if (welcomeChannel.Type != JTokenType.Integer)
+                {
+                    throw new InvalidDataException(
+                        $"{SerializationFields.WelcomeChannel} is expected to be an integer type.");
+                }
+
+                var welcomeChannelId = new Snowflake(welcomeChannel.ToObject<UInt64>());
+                retVal.WelcomeChannel = welcomeChannelId;
+            }
+
+            return retVal;
+        }
+
+        /// <summary>
+        /// Returns a JToken representation of a given guild.
+        /// </summary>
+        /// <param name="guild">Any guild. May not be null.</param>
+        /// <returns>A JToken representation of a given guild.</returns>
+        public static JToken ToJToken(Guild guild)
+        {
+            JObject retVal = new JObject();
+
+            if (guild.OptinCreatorsRoles.Count > 0)
+            {
+                var optinCreatorsRolesArray = new JArray();
+                foreach (var roleId in guild.OptinCreatorsRoles)
+                {
+                    optinCreatorsRolesArray.Add(new JValue(roleId.Value));
+                }
+
+                retVal.Add(SerializationFields.OptinCreatorsRoles, optinCreatorsRolesArray);
+            }
+
+            if (guild.OptinParentCategory.HasValue)
+            {
+                retVal.Add(
+                    SerializationFields.OptinParentCatgory,
+                    new JValue(guild.OptinParentCategory.GetValueOrDefault().Value));
+            }
+
+            if (guild.WelcomeChannel.HasValue)
+            {
+                retVal.Add(
+                    SerializationFields.WelcomeChannel,
+                    new JValue(guild.WelcomeChannel.GetValueOrDefault().Value));
+            }
+
+            return retVal;
+        }
+
+        /// <summary>
+        /// Collection of field names.
+        /// </summary>
+        private static class SerializationFields
+        {
+            // Implementer's note: no need to document fields.
+
+            public const string OptinCreatorsRoles = "OptinCreatorsRoles";
+            public const string OptinParentCatgory = "OptinParentCatgory";
+            public const string WelcomeChannel = "WelcomeChannel";
+        }
+    }
+}

--- a/Data/GuildRepositoryType.cs
+++ b/Data/GuildRepositoryType.cs
@@ -1,7 +1,18 @@
 ﻿namespace Reiati.ChillBot.Data
 {
+    /// <summary>
+    /// The type of a <see cref="IGuildRepository"/> implementation.
+    /// </summary>
     public enum GuildRepositoryType
     {
-        File
+        /// <summary>
+        /// A file system based guild repository.
+        /// </summary>
+        File,
+
+        /// <summary>
+        /// An Azure Blob Storage based guild repository.
+        /// </summary>
+        AzureBlob
     }
 }

--- a/Data/GuildRepositoryType.cs
+++ b/Data/GuildRepositoryType.cs
@@ -1,0 +1,7 @@
+﻿namespace Reiati.ChillBot.Data
+{
+    public enum GuildRepositoryType
+    {
+        File
+    }
+}

--- a/Data/IGuildRepository.cs
+++ b/Data/IGuildRepository.cs
@@ -1,0 +1,19 @@
+﻿using Reiati.ChillBot.Tools;
+using System.Threading.Tasks;
+
+namespace Reiati.ChillBot.Data
+{
+    /// <summary>
+    /// An object representing a repository of <see cref="Guild"/> objects to be checked out and checked in.
+    /// </summary>
+    public interface IGuildRepository
+    {
+        /// <summary>
+        /// Checkout out a <see cref="Guild"/>.
+        /// </summary>
+        /// <param name="guildId">An id representing a guild.</param>
+        /// <param name="recycleResult">A preallocated result that should be returned if passed in.</param>
+        /// <returns>The borrowed guild.</returns>
+        Task<GuildCheckoutResult> Checkout(Snowflake guildId, GuildCheckoutResult recycleResult = null);
+    }
+}

--- a/Data/IGuildRepositoryExtensions.cs
+++ b/Data/IGuildRepositoryExtensions.cs
@@ -6,9 +6,9 @@ using Reiati.ChillBot.Tools;
 namespace Reiati.ChillBot.Data
 {
     /// <summary>
-    /// Helper methods for <see cref="FileBasedGuildRepository"/>.
+    /// Helper methods for <see cref="IGuildRepository"/>.
     /// </summary>
-    public static class FileBasedGuildRepositoryExtensions
+    public static class IGuildRepositoryExtensions
     {
         /// <summary>
         /// Keeps trying to checkout a guild (with backoff) until either maxTimeout has been hit,
@@ -19,20 +19,20 @@ namespace Reiati.ChillBot.Data
         /// <param name="maxTimeout">The maximum amount of time to spend waiting for this to unlock.</param>
         /// <param name="recycleResult">A preallocated result that should be returned if passed in.</param>
         /// <returns>The result.</returns>
-        public static async Task<FileBasedGuildRepository.CheckoutResult> WaitForNotLockedCheckout(
-            this FileBasedGuildRepository repo,
+        public static async Task<GuildCheckoutResult> WaitForNotLockedCheckout(
+            this IGuildRepository repo,
             Snowflake guildId,
             TimeSpan maxTimeout,
-            FileBasedGuildRepository.CheckoutResult recycleResult = null)
+            GuildCheckoutResult recycleResult = null)
         {
             Stopwatch timer = new Stopwatch();
-            var retVal = recycleResult ?? new FileBasedGuildRepository.CheckoutResult();
+            var retVal = recycleResult ?? new GuildCheckoutResult();
             TimeSpan nextDelay = TimeSpan.FromMilliseconds(1);
 
             timer.Start();
             retVal = await repo.Checkout(guildId, retVal);
 
-            while (retVal.Result == FileBasedGuildRepository.CheckoutResult.ResultType.Locked
+            while (retVal.Result == GuildCheckoutResult.ResultType.Locked
                 && timer.Elapsed + nextDelay < maxTimeout)
             {
                 await Task.Delay(nextDelay);

--- a/Engines/CommandEngine.cs
+++ b/Engines/CommandEngine.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Discord;
 using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
+using Reiati.ChillBot.Data;
 using Reiati.ChillBot.EventHandlers;
 using Reiati.ChillBot.Tools;
 
@@ -58,26 +59,33 @@ namespace Reiati.ChillBot.Engines
         private readonly IReadOnlyList<IMessageHandler> guildHandlers;
 
         /// <summary>
+        /// The repository of <see cref="Guild"/> objects.
+        /// </summary>
+        private IGuildRepository guildRepository;
+
+        /// <summary>
         /// Constructs a new <see cref="CommandEngine"/>.
         /// </summary>
         /// <param name="discordClient">A client to interact with discord. May not be null.</param>
-        public CommandEngine(BaseSocketClient discordClient)
+        public CommandEngine(BaseSocketClient discordClient, IGuildRepository guildRepository)
         {
             ValidateArg.IsNotNull(discordClient, nameof(discordClient));
+            ValidateArg.IsNotNull(guildRepository, nameof(guildRepository));
             this.discordClient = discordClient;
+            this.guildRepository = guildRepository;
             this.botId = new Lazy<Snowflake>(this.GetBotId);
 
             this.dmHandlers = new List<IMessageHandler>()
             {
                 new HelpDmHandler(),
-                new LeaveOptinDmHandler(),
+                new LeaveOptinDmHandler(this.guildRepository),
             };
             this.guildHandlers = new List<IMessageHandler>()
             {
                 new HelpGuildHandler(),
-                new JoinOptinGuildHandler(),
-                new ListOptinsGuildHandler(),
-                new NewOptinGuildHandler(),
+                new JoinOptinGuildHandler(this.guildRepository),
+                new ListOptinsGuildHandler(this.guildRepository),
+                new NewOptinGuildHandler(this.guildRepository),
             };
         }
 

--- a/Engines/CommandEngine.cs
+++ b/Engines/CommandEngine.cs
@@ -193,7 +193,7 @@ namespace Reiati.ChillBot.Engines
 
                         case CanHandleResult.ResultStatus.TimedOut:
                             Logger.LogWarning(
-                                "Handler timed out;{{handlerType:{0},timeoutPeriod:{1},message:{2}}}",
+                                "Handler timed out;{{handlerType:{handlerType},timeoutPeriod:{timeoutPeriod},message:{message}}}",
                                 handler.GetType().Name,
                                 canHandle.TimeOutPeriod,
                                 message.Content);

--- a/Engines/CommandEngine.cs
+++ b/Engines/CommandEngine.cs
@@ -67,6 +67,7 @@ namespace Reiati.ChillBot.Engines
         /// Constructs a new <see cref="CommandEngine"/>.
         /// </summary>
         /// <param name="discordClient">A client to interact with discord. May not be null.</param>
+        /// <param name="guildRepository">The repository used to read and write <see cref="Guild"/>s.</param>
         public CommandEngine(BaseSocketClient discordClient, IGuildRepository guildRepository)
         {
             ValidateArg.IsNotNull(discordClient, nameof(discordClient));

--- a/Engines/WelcomeMessageEngine.cs
+++ b/Engines/WelcomeMessageEngine.cs
@@ -39,6 +39,10 @@ namespace Reiati.ChillBot.Engines
         /// </summary>
         private IGuildRepository guildRepository;
 
+        /// <summary>
+        /// Constructs a new <see cref="WelcomeMessageEngine"/>.
+        /// </summary>
+        /// <param name="guildRepository">The repository used to read and write <see cref="Guild"/>s.</param>
         public WelcomeMessageEngine(IGuildRepository guildRepository)
         {
             ValidateArg.IsNotNull(guildRepository, nameof(guildRepository));

--- a/EventHandlers/JoinOptinGuildHandler.cs
+++ b/EventHandlers/JoinOptinGuildHandler.cs
@@ -55,6 +55,7 @@ namespace Reiati.ChillBot.EventHandlers
         /// <summary>
         /// Constructs a <see cref="JoinOptinGuildHandler"/>.
         /// </summary>
+        /// <param name="guildRepository">The repository used to read and write <see cref="Guild"/>s.</param>
         public JoinOptinGuildHandler(IGuildRepository guildRepository)
             : base(JoinOptinGuildHandler.matcher)
         {

--- a/EventHandlers/JoinOptinGuildHandler.cs
+++ b/EventHandlers/JoinOptinGuildHandler.cs
@@ -23,9 +23,9 @@ namespace Reiati.ChillBot.EventHandlers
         /// <summary>
         /// Object pool of <see cref="FileBasedGuildRepository.CheckoutResult"/>s.
         /// </summary>
-        private static ObjectPool<FileBasedGuildRepository.CheckoutResult> checkoutResultPool =
-            new ObjectPool<FileBasedGuildRepository.CheckoutResult>(
-                tFactory: () => new FileBasedGuildRepository.CheckoutResult(),
+        private static ObjectPool<GuildCheckoutResult> checkoutResultPool =
+            new ObjectPool<GuildCheckoutResult>(
+                tFactory: () => new GuildCheckoutResult(),
                 preallocate: 3);
 
         /// <summary>
@@ -48,11 +48,19 @@ namespace Reiati.ChillBot.EventHandlers
         private static readonly Emoji SuccessEmoji = new Emoji("✅");
 
         /// <summary>
+        /// The repository of <see cref="Guild"/> objects.
+        /// </summary>
+        private IGuildRepository guildRepository;
+
+        /// <summary>
         /// Constructs a <see cref="JoinOptinGuildHandler"/>.
         /// </summary>
-        public JoinOptinGuildHandler()
+        public JoinOptinGuildHandler(IGuildRepository guildRepository)
             : base(JoinOptinGuildHandler.matcher)
-        { }
+        {
+            ValidateArg.IsNotNull(guildRepository, nameof(guildRepository));
+            this.guildRepository = guildRepository;
+        }
 
         /// <summary>
         /// Implementers should derive from this to handle a matched message.
@@ -70,10 +78,10 @@ namespace Reiati.ChillBot.EventHandlers
             var checkoutResult = checkoutResultPool.Get();
             try
             {
-                checkoutResult = await FileBasedGuildRepository.Instance.Checkout(guildConnection.Id, checkoutResult);
+                checkoutResult = await this.guildRepository.Checkout(guildConnection.Id, checkoutResult);
                 switch (checkoutResult.Result)
                 {
-                    case FileBasedGuildRepository.CheckoutResult.ResultType.Success:
+                    case GuildCheckoutResult.ResultType.Success:
                         using (var borrowedGuild = checkoutResult.BorrowedGuild)
                         {
                             var guildData = borrowedGuild.Instance;
@@ -114,13 +122,13 @@ namespace Reiati.ChillBot.EventHandlers
                         }
                     break;
 
-                    case FileBasedGuildRepository.CheckoutResult.ResultType.DoesNotExist:
+                    case GuildCheckoutResult.ResultType.DoesNotExist:
                         await message.Channel.SendMessageAsync(
                             text: "This server has not been configured for Chill Bot yet.",
                             messageReference: message.Reference);
                     break;
 
-                    case FileBasedGuildRepository.CheckoutResult.ResultType.Locked:
+                    case GuildCheckoutResult.ResultType.Locked:
                         await message.Channel.SendMessageAsync(
                             text: "Please try again.",
                             messageReference: message.Reference);

--- a/EventHandlers/LeaveOptinDmHandler.cs
+++ b/EventHandlers/LeaveOptinDmHandler.cs
@@ -56,6 +56,7 @@ namespace Reiati.ChillBot.EventHandlers
         /// <summary>
         /// Constructs a <see cref="LeaveOptinDmHandler"/>
         /// </summary>
+        /// <param name="guildRepository">The repository used to read and write <see cref="Guild"/>s.</param>
         public LeaveOptinDmHandler(IGuildRepository guildRepository)
             : base(LeaveOptinDmHandler.matcher)
         {

--- a/EventHandlers/LeaveOptinDmHandler.cs
+++ b/EventHandlers/LeaveOptinDmHandler.cs
@@ -24,9 +24,9 @@ namespace Reiati.ChillBot.EventHandlers
         /// <summary>
         /// Object pool of <see cref="FileBasedGuildRepository.CheckoutResult"/>s.
         /// </summary>
-        private static ObjectPool<FileBasedGuildRepository.CheckoutResult> checkoutResultPool =
-            new ObjectPool<FileBasedGuildRepository.CheckoutResult>(
-                tFactory: () => new FileBasedGuildRepository.CheckoutResult(),
+        private static ObjectPool<GuildCheckoutResult> checkoutResultPool =
+            new ObjectPool<GuildCheckoutResult>(
+                tFactory: () => new GuildCheckoutResult(),
                 preallocate: 3);
 
         /// <summary>
@@ -49,11 +49,19 @@ namespace Reiati.ChillBot.EventHandlers
             HardCoded.Handlers.DefaultRegexTimeout);
 
         /// <summary>
+        /// The repository of <see cref="Guild"/> objects.
+        /// </summary>
+        private IGuildRepository guildRepository;
+
+        /// <summary>
         /// Constructs a <see cref="LeaveOptinDmHandler"/>
         /// </summary>
-        public LeaveOptinDmHandler()
+        public LeaveOptinDmHandler(IGuildRepository guildRepository)
             : base(LeaveOptinDmHandler.matcher)
-        { }
+        {
+            ValidateArg.IsNotNull(guildRepository, nameof(guildRepository));
+            this.guildRepository = guildRepository;
+        }
 
         /// <summary>
         /// Implementers should derive from this to handle a matched message.
@@ -86,11 +94,11 @@ namespace Reiati.ChillBot.EventHandlers
             var checkoutResult = checkoutResultPool.Get();
             try
             {
-                checkoutResult = await FileBasedGuildRepository.Instance.Checkout(guildConnection.Id, checkoutResult)
+                checkoutResult = await this.guildRepository.Checkout(guildConnection.Id, checkoutResult)
                     .ConfigureAwait(false);
                 switch (checkoutResult.Result)
                 {
-                    case FileBasedGuildRepository.CheckoutResult.ResultType.Success:
+                    case GuildCheckoutResult.ResultType.Success:
                         using (var borrowedGuild = checkoutResult.BorrowedGuild)
                         {
                             borrowedGuild.Commit = false;
@@ -131,14 +139,14 @@ namespace Reiati.ChillBot.EventHandlers
                         }
                     break;
 
-                    case FileBasedGuildRepository.CheckoutResult.ResultType.DoesNotExist:
+                    case GuildCheckoutResult.ResultType.DoesNotExist:
                         await message.Channel.SendMessageAsync(
                             text: "This server has not been configured for Chill Bot yet.",
                             messageReference: message.Reference)
                             .ConfigureAwait(false);
                     break;
 
-                    case FileBasedGuildRepository.CheckoutResult.ResultType.Locked:
+                    case GuildCheckoutResult.ResultType.Locked:
                         await message.Channel.SendMessageAsync(
                             text: "Please try again.",
                             messageReference: message.Reference)

--- a/EventHandlers/ListOptinsGuildHandler.cs
+++ b/EventHandlers/ListOptinsGuildHandler.cs
@@ -64,6 +64,7 @@ namespace Reiati.ChillBot.EventHandlers
         /// <summary>
         /// Constructs a <see cref="ListOptinsGuildHandler"/>
         /// </summary>
+        /// <param name="guildRepository">The repository used to read and write <see cref="Guild"/>s.</param>
         public ListOptinsGuildHandler(IGuildRepository guildRepository)
             : base(ListOptinsGuildHandler.matcher)
         {

--- a/EventHandlers/NewOptinGuildHandler.cs
+++ b/EventHandlers/NewOptinGuildHandler.cs
@@ -54,6 +54,7 @@ namespace Reiati.ChillBot.EventHandlers
         /// <summary>
         /// Constructs a <see cref="NewOptinGuildHandler"/>.
         /// </summary>
+        /// <param name="guildRepository">The repository used to read and write <see cref="Guild"/>s.</param>
         public NewOptinGuildHandler(IGuildRepository guildRepository)
             : base(NewOptinGuildHandler.matcher)
         {

--- a/EventHandlers/NewOptinGuildHandler.cs
+++ b/EventHandlers/NewOptinGuildHandler.cs
@@ -23,9 +23,9 @@ namespace Reiati.ChillBot.EventHandlers
         /// <summary>
         /// Object pool of <see cref="FileBasedGuildRepository.CheckoutResult"/>s.
         /// </summary>
-        private static ObjectPool<FileBasedGuildRepository.CheckoutResult> checkoutResultPool =
-            new ObjectPool<FileBasedGuildRepository.CheckoutResult>(
-                tFactory: () => new FileBasedGuildRepository.CheckoutResult(),
+        private static ObjectPool<GuildCheckoutResult> checkoutResultPool =
+            new ObjectPool<GuildCheckoutResult>(
+                tFactory: () => new GuildCheckoutResult(),
                 preallocate: 3);
 
         /// <summary>
@@ -47,11 +47,19 @@ namespace Reiati.ChillBot.EventHandlers
         private static readonly Emoji SuccessEmoji = new Emoji("✅");
 
         /// <summary>
+        /// The repository of <see cref="Guild"/> objects.
+        /// </summary>
+        private IGuildRepository guildRepository;
+
+        /// <summary>
         /// Constructs a <see cref="NewOptinGuildHandler"/>.
         /// </summary>
-        public NewOptinGuildHandler()
+        public NewOptinGuildHandler(IGuildRepository guildRepository)
             : base(NewOptinGuildHandler.matcher)
-        { }
+        {
+            ValidateArg.IsNotNull(guildRepository, nameof(guildRepository));
+            this.guildRepository = guildRepository;
+        }
 
         /// <summary>
         /// Implementers should derive from this to handle a matched message.
@@ -77,10 +85,10 @@ namespace Reiati.ChillBot.EventHandlers
             var checkoutResult = checkoutResultPool.Get();
             try
             {
-                checkoutResult = await FileBasedGuildRepository.Instance.Checkout(guildConnection.Id, checkoutResult);
+                checkoutResult = await this.guildRepository.Checkout(guildConnection.Id, checkoutResult);
                 switch (checkoutResult.Result)
                 {
-                    case FileBasedGuildRepository.CheckoutResult.ResultType.Success:
+                    case GuildCheckoutResult.ResultType.Success:
                         using (var borrowedGuild = checkoutResult.BorrowedGuild)
                         {
                             var guildData = borrowedGuild.Instance;
@@ -122,13 +130,13 @@ namespace Reiati.ChillBot.EventHandlers
                         }
                     break;
 
-                    case FileBasedGuildRepository.CheckoutResult.ResultType.DoesNotExist:
+                    case GuildCheckoutResult.ResultType.DoesNotExist:
                         await message.Channel.SendMessageAsync(
                             text: "This server has not been configured for Chill Bot yet.",
                             messageReference: message.Reference);
                     break;
 
-                    case FileBasedGuildRepository.CheckoutResult.ResultType.Locked:
+                    case GuildCheckoutResult.ResultType.Locked:
                         await message.Channel.SendMessageAsync(
                             text: "Please try again.",
                             messageReference: message.Reference);

--- a/HardCoded/Config.cs
+++ b/HardCoded/Config.cs
@@ -28,6 +28,16 @@ namespace Reiati.ChillBot.HardCoded
         public const string GuildRepositoryTypeConfigKey = "GuildRepository:Type";
 
         /// <summary>
+        /// The format string for the configuration key of the guild repository connection string setting.
+        /// </summary>
+        public const string GuildRepositoryConnectionStringConfigKeyFormat = "GuildRepository:{0}:ConnectionString";
+
+        /// <summary>
+        /// The format string for the configuration key of the guild repository container setting.
+        /// </summary>
+        public const string GuildRepositoryContainerConfigKeyFormat = "GuildRepository:{0}:Container";
+
+        /// <summary>
         /// The path to the default config file.
         /// </summary>
         public static readonly string DefaultConfigFilePath = Path.Combine(".", "config.json");

--- a/HardCoded/Config.cs
+++ b/HardCoded/Config.cs
@@ -23,6 +23,11 @@ namespace Reiati.ChillBot.HardCoded
         public const string ApplicationInsightsInstrumentationKeyConfigKey = "ApplicationInsights:InstrumentationKey";
 
         /// <summary>
+        /// The configuration key of the guild repository type setting.
+        /// </summary>
+        public const string GuildRepositoryTypeConfigKey = "GuildRepository:Type";
+
+        /// <summary>
         /// The path to the default config file.
         /// </summary>
         public static readonly string DefaultConfigFilePath = Path.Combine(".", "config.json");

--- a/Manufacturing.md
+++ b/Manufacturing.md
@@ -44,6 +44,8 @@
 
 > Note: Due to the changing nature of this application, you will have to dig through the code to fill the contents with valid data. Consider starting at `./Data/FileBasedGuildRepository.cs`.
 
+> Note: If you would prefer to use Azure Blob Storage to store these files, upload the JSON file you created to an Azure Blob Storage Container and configure your bot instance to use Azure Blob Storage in the next section.
+
 # Set Up Your Machine
 
 1. Download and install the .NET Core 3.1 SDK and runtime from [Microsoft](https://dotnet.microsoft.com/download).
@@ -62,7 +64,18 @@
 
 5. (Optional) If you would like to send logs to [Application Insights](https://docs.microsoft.com/azure/azure-monitor/app/app-insights-overview), edit the `config.Local.json` file and replace the value of the `ApplicationInsights:InstrumentationKey` property with your instrumentation key. You may also control the level of logs sent to Application Insights by adding filter rules to the `Logging` section of the file as described [here](https://docs.microsoft.com/azure/azure-monitor/app/ilogger#create-filter-rules-in-configuration-with-appsettingsjson).
 
-6. Run the project.
+6. (Optional) If you would like to use [Azure Blob Storage](https://docs.microsoft.com/azure/storage/blobs/storage-blobs-introduction) as your guild repository, modify the `GuildRepository` section of the `config.Local.json` file to match the example below:
+```json
+"GuildRepository": {
+  "Type": "AzureBlob",
+  "AzureBlob": {
+    "ConnectionString": "YOUR_CONNECTION_STRING_HERE",
+    "Container": "guilds"
+  }
+}
+```
+
+7. Run the project.
 ```
 > dotnet run
 ```

--- a/Program.cs
+++ b/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Reiati.ChillBot.Data;
 using Reiati.ChillBot.Services;
 using Reiati.ChillBot.Tools;
 using System;
@@ -80,6 +81,8 @@ namespace Reiati.ChillBot
                 })
                 .ConfigureServices(services =>
                 {
+                    services.AddSingleton<IGuildRepository>(FileBasedGuildRepository.Instance);
+
                     services.AddHostedService<ChillBotService>();
                 })
                 .UseConsoleLifetime();

--- a/Program.cs
+++ b/Program.cs
@@ -94,6 +94,11 @@ namespace Reiati.ChillBot
                         default:
                             services.AddSingleton<IGuildRepository>(FileBasedGuildRepository.Instance);
                             break;
+                        case GuildRepositoryType.AzureBlob:
+                            string connectionString = host.Configuration[string.Format(HardCoded.Config.GuildRepositoryConnectionStringConfigKeyFormat, guildRepositoryType)];
+                            string container = host.Configuration[string.Format(HardCoded.Config.GuildRepositoryContainerConfigKeyFormat, guildRepositoryType)];
+                            services.AddSingleton<IGuildRepository>(new AzureBlobGuildRepository(connectionString, container));
+                            break;
                     }
 
                     services.AddHostedService<ChillBotService>();

--- a/Program.cs
+++ b/Program.cs
@@ -79,9 +79,22 @@ namespace Reiati.ChillBot
                     configBuilder.AddEnvironmentVariables(prefix: HardCoded.Config.EnvironmentVariablePrefix);
                     configBuilder.AddCommandLine(args);
                 })
-                .ConfigureServices(services =>
+                .ConfigureServices((host, services) =>
                 {
-                    services.AddSingleton<IGuildRepository>(FileBasedGuildRepository.Instance);
+                    // Get the type of guild repository to use, defaulting to GuildRepositoryType.File
+                    if (!Enum.TryParse(host.Configuration[HardCoded.Config.GuildRepositoryTypeConfigKey], out GuildRepositoryType guildRepositoryType))
+                    {
+                        guildRepositoryType = GuildRepositoryType.File;
+                    }
+
+                    // Add a singleton for the guild repository
+                    switch (guildRepositoryType)
+                    {
+                        case GuildRepositoryType.File:
+                        default:
+                            services.AddSingleton<IGuildRepository>(FileBasedGuildRepository.Instance);
+                            break;
+                    }
 
                     services.AddHostedService<ChillBotService>();
                 })

--- a/Services/ChillBotService.cs
+++ b/Services/ChillBotService.cs
@@ -99,7 +99,7 @@ namespace Reiati.ChillBot.Services
         /// <returns>When the task has completed.</returns>
         private static Task LogShardConnected(DiscordSocketClient shard)
         {
-            Logger.LogInformation("Shard connected;{{shardId:{0}}}", shard.ShardId);
+            Logger.LogInformation("Shard connected;{{shardId:{shardId}}}", shard.ShardId);
             return Task.CompletedTask;
         }
 
@@ -110,7 +110,7 @@ namespace Reiati.ChillBot.Services
         /// <returns>When the task has completed.</returns>
         private static Task ForwardLogToLogging(Discord.LogMessage log)
         {
-            Logger.Log(log.Severity.ToLogLevel(), log.Exception, "Client log - {0}", log.Message ?? string.Empty);
+            Logger.Log(log.Severity.ToLogLevel(), log.Exception, "Client log - {logMessage}", log.Message ?? string.Empty);
             return Task.CompletedTask;
         }
 

--- a/Services/ChillBotService.cs
+++ b/Services/ChillBotService.cs
@@ -39,6 +39,7 @@ namespace Reiati.ChillBot.Services
         /// Constructs a new <see cref="ChillBotService"/>.
         /// </summary>
         /// <param name="configuration">Application configuration.</param>
+        /// <param name="guildRepository">The repository used to read and write <see cref="Guild"/>s.</param>
         public ChillBotService(IConfiguration configuration, IGuildRepository guildRepository)
         {
             this.configuration = configuration;

--- a/Services/ChillBotService.cs
+++ b/Services/ChillBotService.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Reiati.ChillBot.Data;
 using Reiati.ChillBot.Engines;
 using Reiati.ChillBot.Tools;
 using System.Threading;
@@ -25,6 +26,11 @@ namespace Reiati.ChillBot.Services
         private readonly IConfiguration configuration;
 
         /// <summary>
+        /// Guild repository implementation.
+        /// </summary>
+        private readonly IGuildRepository guildRepository;
+
+        /// <summary>
         /// The client used to connect to Discord.
         /// </summary>
         private DiscordShardedClient client;
@@ -33,9 +39,10 @@ namespace Reiati.ChillBot.Services
         /// Constructs a new <see cref="ChillBotService"/>.
         /// </summary>
         /// <param name="configuration">Application configuration.</param>
-        public ChillBotService(IConfiguration configuration)
+        public ChillBotService(IConfiguration configuration, IGuildRepository guildRepository)
         {
             this.configuration = configuration;
+            this.guildRepository = guildRepository;
         }
 
         /// <inheritdoc/>
@@ -70,8 +77,8 @@ namespace Reiati.ChillBot.Services
             client.Log += ChillBotService.ForwardLogToLogging;
             client.ShardConnected += ChillBotService.LogShardConnected;
 
-            var messageHandler = new CommandEngine(client);
-            var userJoinedHandler = new WelcomeMessageEngine();
+            var messageHandler = new CommandEngine(client, this.guildRepository);
+            var userJoinedHandler = new WelcomeMessageEngine(this.guildRepository);
 
             client.MessageReceived += messageHandler.HandleMessageReceived;
             client.UserJoined += userJoinedHandler.HandleUserJoin;

--- a/config.json
+++ b/config.json
@@ -1,5 +1,8 @@
 {
   "DiscordToken": "abcdefghijklmnopqrstuvwxyz",
+  "GuildRepository": {
+    "Type": "File"
+  },
   "ApplicationInsights": {
     "InstrumentationKey": ""
   },


### PR DESCRIPTION
- Refactor the guild repository interaction to an `IGuildRepository` interface and pass the `IGuildRepository` into the constructor of the objects that require it.
- Allow the guild repository type to be specified via configuration
- Move guild serialization and deserialization to a `GuildConverter` helper class so they can be used by any type of guild repository
- Add support for [Azure Blob Storage](https://docs.microsoft.com/azure/storage/blobs/storage-blobs-introduction) as a guild repository type. It is not used by default, but can be configured by providing a storage account connection string and container name via configuration.
- Updated the Manufacturing document to reflect the additional guild repository option and configuration instructions