### PR TITLE
Add cloud-init and Azure deployment action

### DIFF
--- a/.deploy/cloud-init.yml
+++ b/.deploy/cloud-init.yml
@@ -1,0 +1,55 @@
+#cloud-config
+users:
+  - default
+  - name: chillbot
+    sudo: False
+
+packages:
+  - unzip
+
+write_files:
+  - path: /home/chillbot/sourceDownloadUrl
+    permissions: '0644'
+    content: |
+      <SOURCE_ZIP>
+
+  - path: /home/chillbot/sourceSubDirectory
+    permissions: '0644'
+    content: |
+      <SOURCE_SUB_DIRECTORY>
+
+  - path: /home/chillbot/startChillbot.sh
+    permissions: '0744'
+    content: |
+      source_download_url=$(head -n 1 /home/chillbot/sourceDownloadUrl)
+      source_sub_directory=$(head -n 1 /home/chillbot/sourceSubDirectory)
+
+      rm -rf /home/chillbot/source.zip
+      rm -rf /home/chillbot/source/*
+      wget $source_download_url -O /home/chillbot/source.zip
+      unzip /home/chillbot/source.zip -d /home/chillbot/source/
+      az login --identity --allow-no-subscriptions
+      export DOTNET_CLI_HOME=/home/chillbot
+      export CHILLBOT_GuildRepository__Type=AzureBlob
+      export CHILLBOT_GuildRepository__AzureBlob__Container=guilds
+      export CHILLBOT_GuildRepository__AzureBlob__ConnectionString=$(az keyvault secret show --vault-name <KEY_VAULT_NAME> --name <BLOB_CONNECTION_SECRET_NAME> --query value --out tsv)
+      export CHILLBOT_DiscordToken=$(az keyvault secret show --vault-name <KEY_VAULT_NAME> --name <DISCORD_TOKEN_SECRET_NAME> --query value --out tsv)
+      export CHILLBOT_ApplicationInsights__InstrumentationKey=$(az keyvault secret show --vault-name <KEY_VAULT_NAME> --name <APPLICATION_INSIGHTS_KEY_SECRET_NAME> --query value --out tsv)
+      cd /home/chillbot/source/$source_sub_directory
+      dotnet run --configuration Release
+
+runcmd:
+  - wget https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+  - dpkg -i packages-microsoft-prod.deb
+  - apt-get update
+  - apt-get install -y apt-transport-https
+  - apt-get update
+  - apt-get install -y dotnet-sdk-3.1
+  - curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+  - chown -R chillbot:chillbot /home/chillbot
+  - cd /home/chillbot
+  - sudo -H -u chillbot nohup ./startChillbot.sh &
+
+bootcmd:
+  - cd /home/chillbot
+  - sudo -H -u chillbot test -f ./startChillbot.sh && sudo -H -u chillbot nohup ./startChillbot.sh &

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -1,0 +1,88 @@
+name: Deploy to Azure
+
+# Only run this action manually 
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    environment: Azure
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out the repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a set of commands using the runners shell
+      - name: Replace placeholders in the cloud-init file
+        env:
+          CLOUD_INIT_FILE_PATH: .deploy/cloud-init.yml
+          KEY_VAULT_NAME: ${{ secrets.KEY_VAULT_NAME }}
+          DISCORD_TOKEN_SECRET_NAME: ${{ secrets.DISCORD_TOKEN_SECRET_NAME }}
+          BLOB_CONNECTION_SECRET_NAME: ${{ secrets.BLOB_CONNECTION_SECRET_NAME }}
+          APPLICATION_INSIGHTS_KEY_SECRET_NAME: ${{ secrets.APPLICATION_INSIGHTS_KEY_SECRET_NAME }}
+        run: |
+          source_zip="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/archive/$GITHUB_SHA.zip"
+          source_sub_directory="$(echo $GITHUB_REPOSITORY | sed -e "s|.*/||")-$GITHUB_SHA"
+
+          sed -i "s|<SOURCE_ZIP>|$source_zip|g" $GITHUB_WORKSPACE/$CLOUD_INIT_FILE_PATH
+          sed -i "s|<SOURCE_SUB_DIRECTORY>|$source_sub_directory|g" $GITHUB_WORKSPACE/$CLOUD_INIT_FILE_PATH
+          sed -i "s|<KEY_VAULT_NAME>|$KEY_VAULT_NAME|g" $GITHUB_WORKSPACE/$CLOUD_INIT_FILE_PATH
+          sed -i "s|<BLOB_CONNECTION_SECRET_NAME>|$BLOB_CONNECTION_SECRET_NAME|g" $GITHUB_WORKSPACE/$CLOUD_INIT_FILE_PATH
+          sed -i "s|<DISCORD_TOKEN_SECRET_NAME>|$DISCORD_TOKEN_SECRET_NAME|g" $GITHUB_WORKSPACE/$CLOUD_INIT_FILE_PATH
+          sed -i "s|<APPLICATION_INSIGHTS_KEY_SECRET_NAME>|$APPLICATION_INSIGHTS_KEY_SECRET_NAME|g" $GITHUB_WORKSPACE/$CLOUD_INIT_FILE_PATH
+
+      - name: Azure Login
+        uses: Azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          allow-no-subscriptions: true
+
+      - name: Deploy VMSS
+        env:
+          CLOUD_INIT_FILE_PATH: .deploy/cloud-init.yml
+          VMSS_NAME: ${{ secrets.VMSS_NAME }}
+          VMSS_RESOURCE_GROUP: ${{ secrets.VMSS_RESOURCE_GROUP }}
+          VMSS_LOCATION: ${{ secrets.VMSS_LOCATION }}
+          VMSS_USERNAME: ${{ secrets.VMSS_USERNAME }}
+          SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
+          MANAGED_IDENTITY_ID: ${{ secrets.MANAGED_IDENTITY_ID }}
+          NSG_ID: ${{ secrets.NSG_ID }}
+          PUBLIC_IP_ID: ${{ secrets.PUBLIC_IP_ID }}
+        run: |
+          source_zip="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/archive/$GITHUB_SHA.zip"
+          source_sub_directory="$(echo $GITHUB_REPOSITORY | sed -e "s|.*/||")-$GITHUB_SHA"
+
+          existing_vmss_id=$(az vmss list --resource-group "$VMSS_RESOURCE_GROUP" --query "[?name == '$VMSS_NAME'].id" --output tsv)
+
+          echo "Deploying VMSS"
+          az vmss create --output none \
+            --resource-group "$VMSS_RESOURCE_GROUP" \
+            --name "$VMSS_NAME" \
+            --location "$VMSS_LOCATION" \
+            --vm-sku Standard_B1ls \
+            --storage-sku Standard_LRS \
+            --image UbuntuLTS \
+            --instance-count 1 \
+            --disable-overprovision \
+            --upgrade-policy-mode automatic \
+            --admin-username "$VMSS_USERNAME" \
+            --ssh-key-values "$SSH_PUBLIC_KEY" \
+            --assign-identity "$MANAGED_IDENTITY_ID" \
+            --nsg "$NSG_ID" \
+            --public-ip-address "$PUBLIC_IP_ID" \
+            --custom-data $GITHUB_WORKSPACE/$CLOUD_INIT_FILE_PATH
+
+          if [ -n "$existing_vmss_id" ]; then
+            echo "Updating source location on all VMSS instances"
+            az vmss list-instances --name "$VMSS_NAME" --resource-group "$VMSS_RESOURCE_GROUP" --query "[].id" --output tsv | \
+              az vmss run-command invoke --output none \
+                --ids @- \
+                --command-id RunShellScript \
+                --scripts "echo $source_zip > /home/chillbot/sourceDownloadUrl" "echo $source_sub_directory > /home/chillbot/sourceSubDirectory"
+
+            echo "Restarting all VMSS instances to pick up new source location"
+            az vmss restart --output none \
+              --resource-group "$VMSS_RESOURCE_GROUP" \
+              --name "$VMSS_NAME"
+          fi

--- a/Manufacturing.md
+++ b/Manufacturing.md
@@ -79,3 +79,96 @@
 ```
 > dotnet run
 ```
+
+# Optional: Deploying to Azure from GitHub Actions
+> This is just one of many ways to deploy the Chill Bot service to Azure. The use of the VMSS platform and the VMSS configuration chosen were primarily motivated by keeping the cost of running the bot minimial.
+
+## Prerequisites
+
+- An Azure subscription
+  - If you don't have one, [sign up for free trial](https://azure.microsoft.com/free/).
+- [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) for ease of following the instructions (but the Azure web portal would work too)
+  - You may also want the application-insights extension for Azure CLI: `az extension add --name application-insights`
+- A fork of this repository so you can populate your own secrets for your deployment environment
+
+## Log in to Azure CLI and set the active Azure subscription
+Log in to Azure CLI using the command below or [one of the many other log in options](https://docs.microsoft.com/cli/azure/reference-index#az_login).
+
+```
+az login
+```
+
+If you have a single Azure subscription associated with your account, you can likely skip this next command. That said, it's always a good idea to ensure you're running the remainder of the commands below against the expected subscription.
+
+> If you don't know your subscription name or ID, you can list your subscriptions using `az account list --output table`.
+
+```
+az account set --subscription YOUR_SUBSCRIPTION_NAME_OR_ID_HERE
+```
+
+## Create supporting resources
+
+Create the following Azure resource in your subscription and configure them to your liking:
+
+| Resource        | Example Azure CLI command | Purpose |
+| --------------- | ------------------------- | ------- |
+| Resource Group | `az group create --name ChillBot --location WestUS2` | Group your resource together and limit the scope of access to your Subscription from GitHub actions |
+| Storage Account | `az storage account create --resource-group ChillBot --name chillbotstorage --location WestUS2 --sku Standard_GRS` | Store Discord guild metadata used by Chill Bot |
+| Application Insights (Optional) | `az monitor app-insights component create --resource-group ChillBot --app ChillBot --location WestUS2` | Collect and easily view logs from Chill Bot |
+| Key Vault | `az keyvault create --resource-group ChillBot --name ChillBotKeyVault --location WestUS2` | Store secrets used by the bot to access Azure resources |
+| Managed Identity | `az identity create --resource-group ChillBot --name ChillBotIdentity` | Use to grant the VMSS access to the Key Vault |
+| Network Security Group (NSG) | `az network nsg create --resource-group ChillBot --name ChillBotNsg` | Use to restrict access to your VMSS for added security |
+| Public IP (Optional) | `az network public-ip create --resource-group ChillBot --name ChillBotIP` | Use make your VMSS routable from the public internet (this is only needed if you plan to SSH into the VMSS) |
+
+## Grant the Managed Identity access to read Key Vault secrets
+
+The Managed Identity created above will need to be given permissions to read secrets from Key Vault. This can be achieved using an Azure CLI command like the one below:
+
+```
+az keyvault set-policy --resource-group ChillBot --name ChillBotKeyVault --secret-permissions get --object-id $(az identity show --resource-group ChillBot --name ChillBotIdentity --query principalId --out tsv)
+```
+
+
+## Populate secrets in Key Vault
+
+Populate the following secrets in your Key Vault:
+
+| Secret          | Example Azure CLI command |
+| --------------- | ------------------------- |
+| DiscordToken    | `az keyvault secret set --vault-name ChillBotKeyVault --name DiscordToken --value "abcdefghijklmnopqrstuvwxyz"` |
+| GuildRepositoryConnectionString | `az keyvault secret set --vault-name ChillBotKeyVault --name GuildRepositoryConnectionString --value $(az storage account show-connection-string --resource-group ChillBot --name chillbotstorage --output tsv)` |
+| ApplicationInsightsInstrumentationKey (Optional) | `az keyvault secret set --vault-name ChillBotKeyVault --name GuildRepositoryConnectionString --value $(az monitor app-insights component show --resource-group ChillBot --app ChillBot --query instrumentationKey --output tsv)` |
+
+## Populate secrets in GitHub
+
+Store secrets and other parameters for the [Deploy to Azure](./.github/workflows/azure-deploy.yml) action using [GitHub's encrypted secrets](https://docs.github.com/actions/reference/encrypted-secrets).
+
+1. Create an environment in your respository named "Azure" by following [these instructions](https://docs.github.com/actions/reference/environments#creating-an-environment).
+2. Populate the following secrets in your "Azure" environment by following [these instructions](https://docs.github.com/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
+
+    | Secret          | Where to obtain value     |
+    | --------------- | ------------------------- |
+    | `APPLICATION_INSIGHTS_KEY_SECRET_NAME` | The name of your Application Insight secret in Key Vault. If you followed the secret population above, this will be `ApplicationInsightsInstrumentationKey` |
+    | `AZURE_CREDENTIALS` | Follow [these instructions](https://github.com/marketplace/actions/azure-login#configure-deployment-credentials). For the `--scope` parameter, provide the ID of the resource group you created above (or a separate resource group if prefer to keep the compute separate from the other resources) |
+    | `BLOB_CONNECTION_SECRET_NAME` | The name of your guild repository secret in Key Vault. If you followed the secret population above, this will be `GuildRepositoryConnectionString` |
+    | `DISCORD_TOKEN_SECRET_NAME` | The name of your Discord token secret in Key Vault. If you followed the secret population above, this will be `DiscordToken` |
+    | `KEY_VAULT_NAME` | The name of the Key Vault resource you created above (e.g., `ChillBotKeyVault`). | `MANAGED_IDENTITY_ID` | The resource ID of the Managed Identity you created above. You can use Azure CLI to obtain this: `az identity show --resource-group ChillBot --name ChillBotIdentity --query id --out tsv` |
+    | `NSG_ID` | The resource ID of the Network Security Group you created above (or omit this secret if you want to provision the VMSS without a NSG). You can use Azure CLI to obtain this: `az network nsg show --resource-group Chill-Bot --name ChillBotNsg --query id --out tsv` |
+    | `PUBLIC_IP_ID` (Optional) | The resource ID of the Public IP you created above (or omit this secret if you want to provision the VMSS without a public IP). You can use Azure CLI to obtain this: `az network public-ip show --resource-group Chill-Bot --name ChillBotIP --query id --out tsv` |
+    | `SSH_PUBLIC_KEY` | See [Provide SSH public key when deploying a VM](https://docs.microsoft.com/azure/virtual-machines/linux/create-ssh-keys-detailed#provide-ssh-public-key-when-deploying-a-vm). If you already have an SSH key, you can likely find it at `%USERPROFILE%\.ssh\id_rsa.pub` on Windows or at `~/.ssh/id_rsa.pub` on Linux. If you do not have SSH keys or wish to generate new SSH keys, follow [these instructions](https://docs.microsoft.com/azure/virtual-machines/linux/create-ssh-keys-detailed#generate-keys-with-ssh-keygen). |
+    | `VMSS_LOCATION` | The name of the Azure region where you wish to deploy the compute for the VMSS (e.g., `WestUS2`). You can use `az account list-locations --output table` to see all of the options. |
+    | `VMSS_NAME` | The name of the VMSS to deploy (e.g., `ChillBotDeployment`). |
+    | `VMSS_RESOURCE_GROUP` | The name of the resource group you provided as the `--scope` when generating your `AZURE_CREDENTIALS` secret. If you used the resource group created above, this would be `ChillBot`. |
+    | `VMSS_USERNAME` | The username you wish to use to log in to your VMSS via SSH, should you choose to do so. |
+
+## Deploy to Azure
+
+You're ready to deploy!
+
+Navigate to the "Actions" tab on your GitHub.com fork of the repository where you populated your secrets and follow [these instructions](https://docs.github.com/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow-on-github) to run the "Deploy to Azure" workflow.
+
+The deployment should take 3-5 minutes and the VMSS will require an additional 10-15 minutes to perform an initial bootstrap and install the dependencies from the [cloud-int file](./.deploy/cloud-init.yml). Subsequent deployments will be much faster since the dependencies only need to be installed once.
+
+Once the initial bootstrapping is complete, your Chill Bot should start running automatically and show as available in Discord.
+
+> Remember to populate your Azure Storage Account with the guild information as described in the [Set Up Your "Database"](#set-up-your-database) section above. Your guild files should be placed in a container named "guilds" within your storage account.


### PR DESCRIPTION
This PR provides a workflow for deploying Chill Bot to Azure on the [VMSS](https://docs.microsoft.com/azure/virtual-machine-scale-sets/overview) platform, all via [GitHub Actions](https://docs.github.com/actions). Bootstrapping is done via [cloud-int](https://cloud-init.io/) as described [here](https://docs.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-deploy-app#install-an-app-to-a-linux-vm-with-cloud-init).

I've updated Manufacturing.md with detailed instructions to prepare the resources and populate the required secrets in Key Vault and GitHub. Let me know if you'd prefer for this to be documented in a separate file.

You can see any example of the deployment workflow in action [here](https://github.com/GageAmes/chill-bot/actions/runs/616619537).