### PR TITLE
Make Discord log level configurable

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -82,10 +82,7 @@ namespace Reiati.ChillBot
                 .ConfigureServices((host, services) =>
                 {
                     // Get the type of guild repository to use, defaulting to GuildRepositoryType.File
-                    if (!Enum.TryParse(host.Configuration[HardCoded.Config.GuildRepositoryTypeConfigKey], out GuildRepositoryType guildRepositoryType))
-                    {
-                        guildRepositoryType = GuildRepositoryType.File;
-                    }
+                    GuildRepositoryType guildRepositoryType = host.Configuration.GetValue(HardCoded.Config.GuildRepositoryTypeConfigKey, GuildRepositoryType.File);
 
                     // Add a singleton for the guild repository
                     switch (guildRepositoryType)

--- a/Tools/LogManager.cs
+++ b/Tools/LogManager.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;
+using System.Collections.Concurrent;
 
 namespace Reiati.ChillBot.Tools
 {
     /// <summary>
-    /// Static manager for creating <see cref="ILogger"/> instances.
+    /// Static manager for obtaining <see cref="ILogger"/> instances.
     /// </summary>
     public sealed class LogManager
     {
@@ -13,6 +14,11 @@ namespace Reiati.ChillBot.Tools
         /// The factory to use to create <see cref="ILogger"/> instances.
         /// </summary>
         private static ILoggerFactory LoggerFactory = NullLoggerFactory.Instance;
+
+        /// <summary>
+        /// A cache of loggers that were created.
+        /// </summary>
+        private static ConcurrentDictionary<string, ILogger> LoggerCache = new ConcurrentDictionary<string, ILogger>();
 
         /// <summary>
         /// Configure the <see cref="LogManager"/> to use the provided <see cref="ILoggerFactory"/> when creating logger instances.
@@ -25,23 +31,23 @@ namespace Reiati.ChillBot.Tools
         }
 
         /// <summary>
-        /// Creates a new <see cref="ILogger"/> instance using the provided category name.
+        /// Gets or creates a <see cref="ILogger"/> instance using the provided category name.
         /// </summary>
         /// <param name="categoryName">The category name for messages produced by the logger.</param>
         /// <returns>A new <see cref="ILogger"/> instance.</returns>
         public static ILogger GetLogger(string categoryName)
         {
-            return LoggerFactory.CreateLogger(categoryName);
+            return LogManager.LoggerCache.GetOrAdd(categoryName, (_) => LoggerFactory.CreateLogger(categoryName));
         }
 
         /// <summary>
-        /// Creates a new <see cref="ILogger"/> instance using the full name of the given type.
+        /// Gets or creates a <see cref="ILogger"/> instance using the full name of the given type.
         /// </summary>
         /// <param name="type">The type to use as the category name for messages produced by the logger.</param>
         /// <returns>A new <see cref="ILogger"/> instance.</returns>
         public static ILogger GetLogger(Type type)
         {
-            return LoggerFactory.CreateLogger(type);
+            return LogManager.LoggerCache.GetOrAdd(type.FullName, (_) => LoggerFactory.CreateLogger(type));
         }
     }
 }

--- a/Tools/LoggingExtensions.cs
+++ b/Tools/LoggingExtensions.cs
@@ -33,5 +33,30 @@ namespace Reiati.ChillBot.Tools
                     return LogLevel.None;
             }
         }
+
+        /// <summary>
+        /// Converts a <see cref="LogLevel"/> to a corresponding Discord <see cref="LogSeverity"/>.
+        /// </summary>
+        /// <param name="logLevel">The log level.</param>
+        /// <returns>The <see cref="LogSeverity"/> corresponding to the <see cref="LogLevel"/>.</returns>
+        public static LogSeverity ToLogSeverity(this LogLevel logLevel)
+        {
+            switch (logLevel)
+            {
+                case LogLevel.Trace:
+                    return LogSeverity.Debug;
+                case LogLevel.Debug:
+                    return LogSeverity.Verbose;
+                case LogLevel.Information:
+                    return LogSeverity.Info;
+                case LogLevel.Warning:
+                    return LogSeverity.Warning;
+                case LogLevel.Error:
+                    return LogSeverity.Error;
+                case LogLevel.Critical:
+                default:
+                    return LogSeverity.Critical;
+            }
+        }
     }
 }

--- a/config.json
+++ b/config.json
@@ -9,7 +9,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Reiati.ChillBot": "Information"
+      "Reiati.ChillBot": "Information",
+      "Discord": "Information"
     }
   }
 }


### PR DESCRIPTION
- Use the `Discord.LogMessage.Source` value prefixed by `Discord.` as the category name for Discord client logs.
- Assign the `DiscordSocketConfig.LogLevel` to the minimum log level configured for any `Discord` prefixed category name or the default log category
- Cache `ILogger` instances created by `LogManager` to avoid creating multiple instances for the same category name.