### PR TITLE
Add channel descriptions to opt-in list command and welcome message

### DIFF
--- a/Behavior/OptinChannel.cs
+++ b/Behavior/OptinChannel.cs
@@ -202,8 +202,7 @@ namespace Reiati.ChillBot.Behavior
             var optinsCategoryConnection = guildConnection.GetCategoryChannel(optinsCategory.Value);
             retVal.ToSuccess(
                 optinsCategoryConnection.Channels
-                // TODO: Still need to find the channel descriptions
-                .Select(x => new Tuple<string, string>(x.Name, string.Empty)));
+                .Select(x => new Tuple<string, string>(x.Name, x is SocketTextChannel textChannel ? textChannel.Topic : string.Empty)));
             return retVal;
         }
 

--- a/Engines/WelcomeMessageEngine.cs
+++ b/Engines/WelcomeMessageEngine.cs
@@ -126,7 +126,11 @@ namespace Reiati.ChillBot.Engines
                         foreach (var channel in optinChannelCategory.Channels)
                         {
                             builder.AppendFormat("\n | {0}", channel.Name);
-                            // TODO: Add the channel description.
+
+                            if (channel is SocketTextChannel textChannel && !string.IsNullOrEmpty(textChannel.Topic))
+                            {
+                                builder.AppendFormat(" - {0}", textChannel.Topic);
+                            }
                         }
                         var exampleChannelName = optinChannelCategory.Channels.Last().Name;
                         builder.AppendFormat(

--- a/EventHandlers/ListOptinsGuildHandler.cs
+++ b/EventHandlers/ListOptinsGuildHandler.cs
@@ -194,8 +194,13 @@ namespace Reiati.ChillBot.EventHandlers
                 foreach (var nameDescription in namesDescriptions)
                 {
                     builder.AppendFormat("\n | **{0}**", nameDescription.name);
+
+                    if (!string.IsNullOrEmpty(nameDescription.description))
+                    {
+                        builder.AppendFormat(" - {0}", nameDescription.description);
+                    }
+
                     lastNameAdded = nameDescription.name;
-                    // TODO: Add the channel description.
                 }
                 builder.AppendFormat(
                     "\nLet me know if you're interested in any of them by sending me a message like, \"@Chill Bot join {0}\"",


### PR DESCRIPTION
This PR addresses some TODOs related to including the channel descriptions in the opt-in list command and welcome message output. It appears only text channels have descriptions (AKA topics), so descriptions are only available for `SocketTextChannel` objects.