### PR TITLE
Add commands to rename and update the description of an opt-in

### DIFF
--- a/Behavior/Help.cs
+++ b/Behavior/Help.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace Reiati.ChillBot.Behavior
@@ -21,7 +20,13 @@ namespace Reiati.ChillBot.Behavior
                 "Adds you to the opt-in channel given."),
             new CommandDetails(
                 "new opt-in *channel-name* *a helpful description of your channel*",
-                "Creates a new opt-in channel.")
+                "Creates a new opt-in channel."),
+            new CommandDetails(
+                "rename opt-in *current-channel-name* *new-channel-name*",
+                "Changes the name of an existing opt-in channel."),
+            new CommandDetails(
+                "redescribe opt-in *channel-name* *a helpful description of the channel*",
+                "Changes the description of an existing opt-in channel."),
         };
 
         /// <summary>

--- a/Behavior/OptinChannel.cs
+++ b/Behavior/OptinChannel.cs
@@ -91,6 +91,128 @@ namespace Reiati.ChillBot.Behavior
         }
 
         /// <summary>
+        /// Renames an opt-in channel in the given guild.
+        /// </summary>
+        /// <param name="guildConnection">
+        /// The connection to the guild this channel is being created in. May not be null.
+        /// </param>
+        /// <param name="guildData">Information about this guild. May not be null.</param>
+        /// <param name="requestAuthor">The author of the channel create request. May not be null.</param>
+        /// <param name="currentChannelName">The current name of the channel to rename. May not be null.</param>
+        /// <param name="newChannelName">The requested new name of the channel. May not be null.</param>
+        /// <returns>The result of the request.</returns>
+        public static async Task<RenameResult> Rename(
+            SocketGuild guildConnection,
+            Guild guildData,
+            SocketGuildUser requestAuthor,
+            string currentChannelName,
+            string newChannelName)
+        {
+            ValidateArg.IsNotNullOrWhiteSpace(currentChannelName, nameof(currentChannelName));
+            ValidateArg.IsNotNullOrWhiteSpace(newChannelName, nameof(newChannelName));
+
+            if (!guildData.OptinParentCategory.HasValue)
+            {
+                return RenameResult.NoOptinCategory;
+            }
+            var optinsCategory = guildData.OptinParentCategory.GetValueOrDefault();
+
+            // Check that the request author has permission to create opt-ins (which means they can rename them as well)
+            var hasPermission = PermissionsUtilities.HasPermission(
+                userRoles: requestAuthor.Roles.Select(x => new Snowflake(x.Id)),
+                allowedRoles: guildData.OptinCreatorsRoles);
+            if (!hasPermission)
+            {
+                return RenameResult.NoPermissions;
+            }
+
+            var optinsCategoryConnection = guildConnection.GetCategoryChannel(optinsCategory.Value);
+
+            // Try to get the channel to rename and verify it exists
+            var currentChannel = optinsCategoryConnection.Channels
+                .Where(x => string.Compare(x.Name, currentChannelName, ignoreCase: false) == 0 && x is SocketTextChannel)
+                .Cast<SocketTextChannel>()
+                .SingleOrDefault();
+            if (currentChannel == default)
+            {
+                return RenameResult.NoSuchChannel;
+            }
+
+            // Verify the new channel name is not already in use
+            var newChannelAlreadyExists = optinsCategoryConnection.Channels
+                .Select(x => x.Name)
+                .Any(x => string.Compare(x, newChannelName, ignoreCase: false) == 0);
+            if (newChannelAlreadyExists)
+            {
+                return RenameResult.NewChannelNameUsed;
+            }
+
+            // Modify the channel name
+            await currentChannel.ModifyAsync(settings =>
+            {
+                settings.Name = newChannelName;
+            }).ConfigureAwait(false);
+
+            return RenameResult.Success;
+        }
+
+        /// <summary>
+        /// Updates the description of an opt-in channel in the given guild.
+        /// </summary>
+        /// <param name="guildConnection">
+        /// The connection to the guild this channel is being created in. May not be null.
+        /// </param>
+        /// <param name="guildData">Information about this guild. May not be null.</param>
+        /// <param name="requestAuthor">The author of the channel create request. May not be null.</param>
+        /// <param name="channelName">The current name of the channel to rename. May not be null.</param>
+        /// <param name="description">The requested description of the channel.</param>
+        /// <returns>The result of the request.</returns>
+        public static async Task<UpdateDescriptionResult> UpdateDescription(
+            SocketGuild guildConnection,
+            Guild guildData,
+            SocketGuildUser requestAuthor,
+            string channelName,
+            string description)
+        {
+            ValidateArg.IsNotNullOrWhiteSpace(channelName, nameof(channelName));
+
+            if (!guildData.OptinParentCategory.HasValue)
+            {
+                return UpdateDescriptionResult.NoOptinCategory;
+            }
+            var optinsCategory = guildData.OptinParentCategory.GetValueOrDefault();
+
+            // Check that the request author has permission to create opt-ins (which means they can update their description as well)
+            var hasPermission = PermissionsUtilities.HasPermission(
+                userRoles: requestAuthor.Roles.Select(x => new Snowflake(x.Id)),
+                allowedRoles: guildData.OptinCreatorsRoles);
+            if (!hasPermission)
+            {
+                return UpdateDescriptionResult.NoPermissions;
+            }
+
+            var optinsCategoryConnection = guildConnection.GetCategoryChannel(optinsCategory.Value);
+
+            // Try to get the channel to update and verify it exists
+            var currentChannel = optinsCategoryConnection.Channels
+                .Where(x => string.Compare(x.Name, channelName, ignoreCase: false) == 0 && x is SocketTextChannel)
+                .Cast<SocketTextChannel>()
+                .SingleOrDefault();
+            if (currentChannel == default)
+            {
+                return UpdateDescriptionResult.NoSuchChannel;
+            }
+
+            // Modify the channel description
+            await currentChannel.ModifyAsync(settings =>
+            {
+                settings.Topic = description ?? string.Empty;
+            }).ConfigureAwait(false);
+
+            return UpdateDescriptionResult.Success;
+        }
+
+        /// <summary>
         /// Joins an optin channel.
         /// </summary>
         /// <param name="guildConnection">
@@ -234,6 +356,47 @@ namespace Reiati.ChillBot.Behavior
 
             /// <summary></summary>,
             ChannelNameUsed
+        }
+
+        /// <summary>
+        /// Result type of a <see cref="OptinChannel.Rename(SocketGuild, Guild, SocketGuildUser, string, string)"/>
+        /// call.
+        /// </summary>
+        public enum RenameResult
+        {
+            /// <summary>An optin channel was successfully renamed.</summary>
+            Success,
+
+            /// <summary>The server has no Opt-in channel category.</summary>
+            NoOptinCategory,
+
+            /// <summary>The request author does not have permission to rename opt-in channels.</summary>
+            NoPermissions,
+
+            /// <summary>The current channel name given does not exist as an opt-in channel (or at all.)</summary>
+            NoSuchChannel,
+
+            /// <summary>The new channel name given is already in use by another opt-in channel.</summary>,
+            NewChannelNameUsed,
+        }
+
+        /// <summary>
+        /// Result type of a <see cref="OptinChannel.UpdateDescription(SocketGuild, Guild, SocketGuildUser, string, string)"/>
+        /// call.
+        /// </summary>
+        public enum UpdateDescriptionResult
+        {
+            /// <summary>An optin channel's description was successfully updated.</summary>
+            Success,
+
+            /// <summary>The server has no Opt-in channel category.</summary>
+            NoOptinCategory,
+
+            /// <summary>The request author does not have permission to update the description of opt-in channels.</summary>
+            NoPermissions,
+
+            /// <summary>The channel name given does not exist as an opt-in channel (or at all.)</summary>
+            NoSuchChannel,
         }
 
         /// <summary>

--- a/Engines/CommandEngine.cs
+++ b/Engines/CommandEngine.cs
@@ -87,6 +87,8 @@ namespace Reiati.ChillBot.Engines
                 new JoinOptinGuildHandler(this.guildRepository),
                 new ListOptinsGuildHandler(this.guildRepository),
                 new NewOptinGuildHandler(this.guildRepository),
+                new RenameOptinGuildHandler(this.guildRepository),
+                new RedescribeOptinGuildHandler(this.guildRepository),
             };
         }
 

--- a/EventHandlers/RedescribeOptinGuildHandler.cs
+++ b/EventHandlers/RedescribeOptinGuildHandler.cs
@@ -1,0 +1,168 @@
+﻿using Discord;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+using Reiati.ChillBot.Behavior;
+using Reiati.ChillBot.Data;
+using Reiati.ChillBot.Tools;
+using System;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Reiati.ChillBot.EventHandlers
+{
+    /// <summary>
+    /// Responsible for handling messages in a guild, attempting to update the description of opt-in channels.
+    /// </summary>
+    public class RedescribeOptinGuildHandler : AbstractRegexHandler
+    {
+        /// <summary>
+        /// A logger.
+        /// </summary>
+        private static ILogger Logger = LogManager.GetLogger(typeof(RedescribeOptinGuildHandler));
+
+        /// <summary>
+        /// Object pool of <see cref="GuildCheckoutResult"/>s.
+        /// </summary>
+        private static ObjectPool<GuildCheckoutResult> checkoutResultPool =
+            new ObjectPool<GuildCheckoutResult>(
+                tFactory: () => new GuildCheckoutResult(),
+                preallocate: 3);
+
+        /// <summary>
+        /// The matcher for detecting the phrases:
+        /// - <@123> redescribe opt-in {1} {2}
+        /// - <@123> redescribe opt-in {1}
+        /// - <@123> redescribe opt in {1} {2}
+        /// - <@123> redescribe optin {1} {2}
+        /// - <@123> re-describe opt-in {1} {2}
+        /// - <@123> re describe opt-in {1} {2}
+        /// And captures the channel name into a named capture group "channel", and the new description into a named capture group "description".
+        /// </summary>
+        private static Regex matcher = new Regex(
+            @"^\s*\<\@\!?\d+\>\s*re(?:-|\s)?describe\s+opt(?:-|\s)?in\s+(?<channel>\S+)\s*(?<description>.*)$",
+            RegexOptions.IgnoreCase,
+            HardCoded.Handlers.DefaultRegexTimeout);
+
+        /// <summary>
+        /// Emoji sent upon successful operation.
+        /// </summary>
+        private static readonly Emoji SuccessEmoji = new Emoji("✅");
+
+        /// <summary>
+        /// The repository of <see cref="Guild"/> objects.
+        /// </summary>
+        private IGuildRepository guildRepository;
+
+        /// <summary>
+        /// Constructs a <see cref="RedescribeOptinGuildHandler"/>.
+        /// </summary>
+        /// <param name="guildRepository">The repository used to read and write <see cref="Guild"/>s.</param>
+        public RedescribeOptinGuildHandler(IGuildRepository guildRepository)
+            : base(RedescribeOptinGuildHandler.matcher)
+        {
+            ValidateArg.IsNotNull(guildRepository, nameof(guildRepository));
+            this.guildRepository = guildRepository;
+        }
+
+        /// <summary>
+        /// Implementers should derive from this to handle a matched message.
+        /// </summary>
+        /// <param name="message">The message received.</param>
+        /// <param name="handleCache">The match object returned from the regex match.</param>
+        /// <returns>The handle task.</returns>
+        protected override async Task HandleMatchedMessage(SocketMessage message, Match handleCache)
+        {
+            var messageChannel = message.Channel as SocketGuildChannel;
+            var author = message.Author as SocketGuildUser;
+            var guildConnection = messageChannel.Guild;
+            var messageReference = new MessageReference(message.Id, messageChannel.Id, guildConnection.Id);
+            var channelName = handleCache.Groups["channel"].Captures[0].Value;
+            var description = handleCache.Groups["description"].Captures[0].Value;
+
+            if (string.IsNullOrEmpty(description))
+            {
+                await message.Channel.SendMessageAsync(
+                    text: "The channel's description must be something meaningful. Ideally something that explains what it is.",
+                    messageReference: messageReference);
+                return;
+            }
+
+            var checkoutResult = checkoutResultPool.Get();
+            try
+            {
+                checkoutResult = await this.guildRepository.Checkout(guildConnection.Id, checkoutResult);
+                switch (checkoutResult.Result)
+                {
+                    case GuildCheckoutResult.ResultType.Success:
+                        using (var borrowedGuild = checkoutResult.BorrowedGuild)
+                        {
+                            var guildData = borrowedGuild.Instance;
+                            var updateResult = await OptinChannel.UpdateDescription(
+                                guildConnection: guildConnection,
+                                guildData: guildData,
+                                requestAuthor: author,
+                                channelName: channelName,
+                                description: description);
+                            borrowedGuild.Commit = updateResult == OptinChannel.UpdateDescriptionResult.Success;
+
+                            switch (updateResult)
+                            {
+                                case OptinChannel.UpdateDescriptionResult.Success:
+                                    await message.AddReactionAsync(RedescribeOptinGuildHandler.SuccessEmoji);
+                                    break;
+
+                                case OptinChannel.UpdateDescriptionResult.NoPermissions:
+                                    await message.Channel.SendMessageAsync(
+                                        text: "You do not have permission to update the description of opt-in channels.",
+                                        messageReference: messageReference);
+                                    break;
+
+                                case OptinChannel.UpdateDescriptionResult.NoOptinCategory:
+                                    await message.Channel.SendMessageAsync(
+                                        text: "This server is not set up for opt-in channels.",
+                                        messageReference: messageReference);
+                                    break;
+
+                                case OptinChannel.UpdateDescriptionResult.NoSuchChannel:
+                                    await message.Channel.SendMessageAsync(
+                                        text: "An opt-in channel with this name does not exist.",
+                                        messageReference: messageReference);
+                                    break;
+
+                                default:
+                                    throw new NotImplementedException(updateResult.ToString());
+                            }
+                        }
+                        break;
+
+                    case GuildCheckoutResult.ResultType.DoesNotExist:
+                        await message.Channel.SendMessageAsync(
+                            text: "This server has not been configured for Chill Bot yet.",
+                            messageReference: messageReference);
+                        break;
+
+                    case GuildCheckoutResult.ResultType.Locked:
+                        await message.Channel.SendMessageAsync(
+                            text: "Please try again.",
+                            messageReference: messageReference);
+                        break;
+
+                    default:
+                        throw new NotImplementedException(checkoutResult.Result.ToString());
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e, "Request dropped - exception thrown");
+                await message.Channel.SendMessageAsync(
+                    text: "Something went wrong trying to do this for you. File a bug report with Chill Bot.",
+                    messageReference: messageReference);
+            }
+            finally
+            {
+                checkoutResult.ClearReferences();
+                checkoutResultPool.Return(checkoutResult);
+            }
+        }
+    }
+}

--- a/EventHandlers/RenameOptinGuildHandler.cs
+++ b/EventHandlers/RenameOptinGuildHandler.cs
@@ -1,0 +1,172 @@
+﻿using Discord;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+using Reiati.ChillBot.Behavior;
+using Reiati.ChillBot.Data;
+using Reiati.ChillBot.Tools;
+using System;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Reiati.ChillBot.EventHandlers
+{
+    /// <summary>
+    /// Responsible for handling messages in a guild, attempting to rename opt-in channels.
+    /// </summary>
+    public class RenameOptinGuildHandler : AbstractRegexHandler
+    {
+        /// <summary>
+        /// A logger.
+        /// </summary>
+        private static ILogger Logger = LogManager.GetLogger(typeof(RenameOptinGuildHandler));
+
+        /// <summary>
+        /// Object pool of <see cref="GuildCheckoutResult"/>s.
+        /// </summary>
+        private static ObjectPool<GuildCheckoutResult> checkoutResultPool =
+            new ObjectPool<GuildCheckoutResult>(
+                tFactory: () => new GuildCheckoutResult(),
+                preallocate: 3);
+
+        /// <summary>
+        /// The matcher for detecting the phrases:
+        /// - <@123> rename opt-in {1} {2}
+        /// - <@123> rename opt-in {1}
+        /// - <@123> rename opt in {1} {2}
+        /// - <@123> rename optin {1} {2}
+        /// And captures the current channel name into a named capture group "currentName", and the new channel name into a named capture group "newName".
+        /// </summary>
+        private static Regex matcher = new Regex(
+            @"^\s*\<\@\!?\d+\>\s*rename\s+opt(?:-|\s)?in\s+(?<currentName>\S+)\s*(?<newName>\S*)$",
+            RegexOptions.IgnoreCase,
+            HardCoded.Handlers.DefaultRegexTimeout);
+
+        /// <summary>
+        /// Emoji sent upon successful operation.
+        /// </summary>
+        private static readonly Emoji SuccessEmoji = new Emoji("✅");
+
+        /// <summary>
+        /// The repository of <see cref="Guild"/> objects.
+        /// </summary>
+        private IGuildRepository guildRepository;
+
+        /// <summary>
+        /// Constructs a <see cref="RenameOptinGuildHandler"/>.
+        /// </summary>
+        /// <param name="guildRepository">The repository used to read and write <see cref="Guild"/>s.</param>
+        public RenameOptinGuildHandler(IGuildRepository guildRepository)
+            : base(RenameOptinGuildHandler.matcher)
+        {
+            ValidateArg.IsNotNull(guildRepository, nameof(guildRepository));
+            this.guildRepository = guildRepository;
+        }
+
+        /// <summary>
+        /// Implementers should derive from this to handle a matched message.
+        /// </summary>
+        /// <param name="message">The message received.</param>
+        /// <param name="handleCache">The match object returned from the regex match.</param>
+        /// <returns>The handle task.</returns>
+        protected override async Task HandleMatchedMessage(SocketMessage message, Match handleCache)
+        {
+            var messageChannel = message.Channel as SocketGuildChannel;
+            var author = message.Author as SocketGuildUser;
+            var guildConnection = messageChannel.Guild;
+            var messageReference = new MessageReference(message.Id, messageChannel.Id, guildConnection.Id);
+            var currentChannelName = handleCache.Groups["currentName"].Captures[0].Value;
+            var newChannelName = handleCache.Groups["newName"].Captures[0].Value;
+
+            if (string.IsNullOrEmpty(newChannelName))
+            {
+                await message.Channel.SendMessageAsync(
+                    text: "The channel's new name must be something meaningful.",
+                    messageReference: messageReference);
+                return;
+            }
+
+            var checkoutResult = checkoutResultPool.Get();
+            try
+            {
+                checkoutResult = await this.guildRepository.Checkout(guildConnection.Id, checkoutResult);
+                switch (checkoutResult.Result)
+                {
+                    case GuildCheckoutResult.ResultType.Success:
+                        using (var borrowedGuild = checkoutResult.BorrowedGuild)
+                        {
+                            var guildData = borrowedGuild.Instance;
+                            var renameResult = await OptinChannel.Rename(
+                                guildConnection: guildConnection,
+                                guildData: guildData,
+                                requestAuthor: author,
+                                currentChannelName: currentChannelName,
+                                newChannelName: newChannelName);
+                            borrowedGuild.Commit = renameResult == OptinChannel.RenameResult.Success;
+
+                            switch (renameResult)
+                            {
+                                case OptinChannel.RenameResult.Success:
+                                    await message.AddReactionAsync(RenameOptinGuildHandler.SuccessEmoji);
+                                    break;
+
+                                case OptinChannel.RenameResult.NoPermissions:
+                                    await message.Channel.SendMessageAsync(
+                                        text: "You do not have permission to rename opt-in channels.",
+                                        messageReference: messageReference);
+                                    break;
+
+                                case OptinChannel.RenameResult.NoOptinCategory:
+                                    await message.Channel.SendMessageAsync(
+                                        text: "This server is not set up for opt-in channels.",
+                                        messageReference: messageReference);
+                                    break;
+
+                                case OptinChannel.RenameResult.NoSuchChannel:
+                                    await message.Channel.SendMessageAsync(
+                                        text: "An opt-in channel with this name does not exist.",
+                                        messageReference: messageReference);
+                                    break;
+
+                                case OptinChannel.RenameResult.NewChannelNameUsed:
+                                    await message.Channel.SendMessageAsync(
+                                        text: "An opt-in channel with this new name already exists.",
+                                        messageReference: messageReference);
+                                    break;
+
+                                default:
+                                    throw new NotImplementedException(renameResult.ToString());
+                            }
+                        }
+                        break;
+
+                    case GuildCheckoutResult.ResultType.DoesNotExist:
+                        await message.Channel.SendMessageAsync(
+                            text: "This server has not been configured for Chill Bot yet.",
+                            messageReference: messageReference);
+                        break;
+
+                    case GuildCheckoutResult.ResultType.Locked:
+                        await message.Channel.SendMessageAsync(
+                            text: "Please try again.",
+                            messageReference: messageReference);
+                        break;
+
+                    default:
+                        throw new NotImplementedException(checkoutResult.Result.ToString());
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e, "Request dropped - exception thrown");
+                await message.Channel.SendMessageAsync(
+                    text: "Something went wrong trying to do this for you. File a bug report with Chill Bot.",
+                    messageReference: messageReference);
+            }
+            finally
+            {
+                checkoutResult.ClearReferences();
+                checkoutResultPool.Return(checkoutResult);
+            }
+        }
+    }
+}

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -22,6 +22,8 @@ In Servers:
  - **@Chill Bot new opt-in \[channel name\] \[channel description\]** - Creates a new opt-in channel, and associated role.
  - **@Chill Bot join \[channel name\]** - Assigns that member the role to view the channel given.
  - **@Chill Bot list opt-ins** - Lists all of the opt-in channels.
+ - **@Chill Bot rename opt-in \[current channel name\] \[new channel name\]** - Changes the name of an existing opt-in channel.
+ - **@Chill Bot redescribe opt-in \[channel name\] \[channel description\]** - Changes the description of an existing opt-in channel.
  - **@Chill Bot help** - Lists all of the commands available in a server.
 
 In DMs:


### PR DESCRIPTION
This PR adds two new commands to modify an existing opt-in channel:
- `rename opt-in *current-channel-name* *new-channel-name*` - Changes the name of an opt-in channel.
- `redescribe opt-in *channel-name* *a helpful description of the channel*` - Changes the description of an opt-in channel.