### PR TITLE
Correct message reference so the bot replies to the correct message

### DIFF
--- a/EventHandlers/HelpGuildHandler.cs
+++ b/EventHandlers/HelpGuildHandler.cs
@@ -1,9 +1,9 @@
-using System;
 using System.Threading.Tasks;
 using System.Text;
 using System.Text.RegularExpressions;
 using Discord.WebSocket;
 using Reiati.ChillBot.Behavior;
+using Discord;
 
 namespace Reiati.ChillBot.EventHandlers
 {
@@ -44,7 +44,10 @@ namespace Reiati.ChillBot.EventHandlers
         protected override async Task HandleMatchedMessage(SocketMessage message, Match handleCache)
         {
             var messageChannel = message.Channel as SocketGuildChannel;
-            await message.Channel.SendMessageAsync(HelpGuildHandler.HelpMessage);
+            var messageReference = new MessageReference(message.Id, messageChannel.Id, messageChannel.Guild.Id);
+            await message.Channel.SendMessageAsync(HelpGuildHandler.HelpMessage,
+                messageReference: messageReference)
+                .ConfigureAwait(false);
         }
 
         /// <summary>

--- a/EventHandlers/JoinOptinGuildHandler.cs
+++ b/EventHandlers/JoinOptinGuildHandler.cs
@@ -74,6 +74,7 @@ namespace Reiati.ChillBot.EventHandlers
             var messageChannel = message.Channel as SocketGuildChannel;
             var author = message.Author as SocketGuildUser;
             var guildConnection = messageChannel.Guild;
+            var messageReference = new MessageReference(message.Id, messageChannel.Id, guildConnection.Id);
             var channelName = handleCache.Groups["channel"].Captures[0].Value;
 
             var checkoutResult = checkoutResultPool.Get();
@@ -96,25 +97,29 @@ namespace Reiati.ChillBot.EventHandlers
                             switch (joinResult)
                             {
                                 case OptinChannel.JoinResult.Success:
-                                    await message.AddReactionAsync(JoinOptinGuildHandler.SuccessEmoji);
+                                    await message.AddReactionAsync(JoinOptinGuildHandler.SuccessEmoji)
+                                        .ConfigureAwait(false);
                                 break;
 
                                 case OptinChannel.JoinResult.NoSuchChannel:
                                     await message.Channel.SendMessageAsync(
                                         text: "An opt-in channel with this name does not exist.",
-                                        messageReference: message.Reference);
+                                        messageReference: messageReference)
+                                        .ConfigureAwait(false);
                                 break;
 
                                 case OptinChannel.JoinResult.NoOptinCategory:
                                     await message.Channel.SendMessageAsync(
                                         text: "This server is not set up for opt-in channels.",
-                                        messageReference: message.Reference);
+                                        messageReference: messageReference)
+                                        .ConfigureAwait(false);
                                 break;
 
                                 case OptinChannel.JoinResult.RoleMissing:
                                     await message.Channel.SendMessageAsync(
                                         text: "The role for this channel went missing. Talk to your server admin.",
-                                        messageReference: message.Reference);
+                                        messageReference: messageReference)
+                                        .ConfigureAwait(false);
                                 break;
 
                                 default:
@@ -126,13 +131,15 @@ namespace Reiati.ChillBot.EventHandlers
                     case GuildCheckoutResult.ResultType.DoesNotExist:
                         await message.Channel.SendMessageAsync(
                             text: "This server has not been configured for Chill Bot yet.",
-                            messageReference: message.Reference);
+                            messageReference: messageReference)
+                            .ConfigureAwait(false);
                     break;
 
                     case GuildCheckoutResult.ResultType.Locked:
                         await message.Channel.SendMessageAsync(
                             text: "Please try again.",
-                            messageReference: message.Reference);
+                            messageReference: messageReference)
+                            .ConfigureAwait(false);
                     break;
 
                     default:
@@ -144,7 +151,8 @@ namespace Reiati.ChillBot.EventHandlers
                 Logger.LogError(e, "Request dropped - exception thrown");
                 await message.Channel.SendMessageAsync(
                     text: "Something went wrong trying to do this for you. File a bug report with Chill Bot.",
-                    messageReference: message.Reference);
+                    messageReference: messageReference)
+                    .ConfigureAwait(false);
             }
             finally
             {

--- a/EventHandlers/LeaveOptinDmHandler.cs
+++ b/EventHandlers/LeaveOptinDmHandler.cs
@@ -142,15 +142,13 @@ namespace Reiati.ChillBot.EventHandlers
 
                     case GuildCheckoutResult.ResultType.DoesNotExist:
                         await message.Channel.SendMessageAsync(
-                            text: "This server has not been configured for Chill Bot yet.",
-                            messageReference: message.Reference)
+                            text: "This server has not been configured for Chill Bot yet.")
                             .ConfigureAwait(false);
                     break;
 
                     case GuildCheckoutResult.ResultType.Locked:
                         await message.Channel.SendMessageAsync(
-                            text: "Please try again.",
-                            messageReference: message.Reference)
+                            text: "Please try again.")
                             .ConfigureAwait(false);
                     break;
 
@@ -162,8 +160,7 @@ namespace Reiati.ChillBot.EventHandlers
             {
                 Logger.LogError(e, "Request dropped - exception thrown");
                 await message.Channel.SendMessageAsync(
-                    text: "Something went wrong trying to do this for you. File a bug report with Chill Bot.",
-                    messageReference: message.Reference)
+                    text: "Something went wrong trying to do this for you. File a bug report with Chill Bot.")
                     .ConfigureAwait(false);
             }
             finally

--- a/EventHandlers/ListOptinsGuildHandler.cs
+++ b/EventHandlers/ListOptinsGuildHandler.cs
@@ -8,6 +8,7 @@ using Reiati.ChillBot.Behavior;
 using Reiati.ChillBot.Data;
 using Reiati.ChillBot.Tools;
 using Microsoft.Extensions.Logging;
+using Discord;
 
 namespace Reiati.ChillBot.EventHandlers
 {
@@ -81,8 +82,8 @@ namespace Reiati.ChillBot.EventHandlers
         protected override async Task HandleMatchedMessage(SocketMessage message, Match handleCache)
         {
             var messageChannel = message.Channel as SocketGuildChannel;
-            var author = message.Author as SocketGuildUser;
             var guildConnection = messageChannel.Guild;
+            var messageReference = new MessageReference(message.Id, messageChannel.Id, guildConnection.Id);
 
             var checkoutResult = checkoutResultPool.Get();
             try
@@ -103,13 +104,15 @@ namespace Reiati.ChillBot.EventHandlers
                     case GuildCheckoutResult.ResultType.DoesNotExist:
                         await message.Channel.SendMessageAsync(
                             text: "This server has not been configured for Chill Bot yet.",
-                            messageReference: message.Reference);
+                            messageReference: messageReference)
+                            .ConfigureAwait(false);
                     break;
 
                     case GuildCheckoutResult.ResultType.Locked:
                         await message.Channel.SendMessageAsync(
                             text: "Please try again.",
-                            messageReference: message.Reference);
+                            messageReference: messageReference)
+                            .ConfigureAwait(false);
                     break;
 
                     default:
@@ -121,7 +124,8 @@ namespace Reiati.ChillBot.EventHandlers
                 Logger.LogError(e, "Request dropped - exception thrown");
                 await message.Channel.SendMessageAsync(
                     text: "Something went wrong trying to do this for you. File a bug report with Chill Bot.",
-                    messageReference: message.Reference);
+                    messageReference: messageReference)
+                    .ConfigureAwait(false);
             }
             finally
             {
@@ -139,6 +143,7 @@ namespace Reiati.ChillBot.EventHandlers
         /// <returns>When listing has completed.</returns>
         private static async Task ListOptinChannels(SocketMessage message, SocketGuild guildConnection, Guild guildData)
         {
+            var messageReference = new MessageReference(message.Id, message.Channel.Id, guildConnection.Id);
             var listResult = listResultPool.Get();
             try
             {
@@ -151,20 +156,24 @@ namespace Reiati.ChillBot.EventHandlers
                         if (namesDescriptions.Count > 0)
                         {
                             await message.Channel.SendMessageAsync(
-                                ListOptinsGuildHandler.GetListingMessage(namesDescriptions));
+                                ListOptinsGuildHandler.GetListingMessage(namesDescriptions),
+                                messageReference: messageReference)
+                                .ConfigureAwait(false);
                         }
                         else
                         {
                             await message.Channel.SendMessageAsync(
                                 text: "This server deosn't have any opt-in channels yet. Try creating one with \"@Chill Bot new opt-in channel-name A description of your channel!\"",
-                                messageReference: message.Reference);
+                                messageReference: messageReference)
+                                .ConfigureAwait(false);
                         }
                     break;
 
                     case OptinChannel.ListResult.ResultType.NoOptinCategory:
                         await message.Channel.SendMessageAsync(
                             text: "This server is not set up for opt-in channels.",
-                            messageReference: message.Reference);
+                            messageReference: messageReference)
+                            .ConfigureAwait(false);
                     break;
 
                     default:

--- a/EventHandlers/NewOptinGuildHandler.cs
+++ b/EventHandlers/NewOptinGuildHandler.cs
@@ -73,13 +73,14 @@ namespace Reiati.ChillBot.EventHandlers
             var messageChannel = message.Channel as SocketGuildChannel;
             var author = message.Author as SocketGuildUser;
             var guildConnection = messageChannel.Guild;
+            var messageReference = new MessageReference(message.Id, messageChannel.Id, guildConnection.Id);
             var channelName = handleCache.Groups[1].Captures[0].Value;
 
             if (!NewOptinGuildHandler.TryGetSecondMatch(handleCache, out string description))
             {
                 await message.Channel.SendMessageAsync(
                     text: "The new channel's description must be something meaningful. Ideally something that explains what it is.",
-                    messageReference: message.Reference);
+                    messageReference: messageReference);
                 return;
             }
 
@@ -104,25 +105,29 @@ namespace Reiati.ChillBot.EventHandlers
                             switch (createResult)
                             {
                                 case OptinChannel.CreateResult.Success:
-                                    await message.AddReactionAsync(NewOptinGuildHandler.SuccessEmoji);
+                                    await message.AddReactionAsync(NewOptinGuildHandler.SuccessEmoji)
+                                        .ConfigureAwait(false);
                                 break;
 
                                 case OptinChannel.CreateResult.NoPermissions:
                                     await message.Channel.SendMessageAsync(
                                         text: "You do not have permission to create opt-in channels.",
-                                        messageReference: message.Reference);
+                                        messageReference: messageReference)
+                                        .ConfigureAwait(false);
                                 break;
 
                                 case OptinChannel.CreateResult.NoOptinCategory:
                                     await message.Channel.SendMessageAsync(
                                         text: "This server is not set up for opt-in channels.",
-                                        messageReference: message.Reference);
+                                        messageReference: messageReference)
+                                        .ConfigureAwait(false);
                                 break;
 
                                 case OptinChannel.CreateResult.ChannelNameUsed:
                                     await message.Channel.SendMessageAsync(
                                         text: "An opt-in channel with this name already exists.",
-                                        messageReference: message.Reference);
+                                        messageReference: messageReference)
+                                        .ConfigureAwait(false);
                                 break;
 
                                 default:
@@ -134,13 +139,15 @@ namespace Reiati.ChillBot.EventHandlers
                     case GuildCheckoutResult.ResultType.DoesNotExist:
                         await message.Channel.SendMessageAsync(
                             text: "This server has not been configured for Chill Bot yet.",
-                            messageReference: message.Reference);
+                            messageReference: messageReference)
+                            .ConfigureAwait(false);
                     break;
 
                     case GuildCheckoutResult.ResultType.Locked:
                         await message.Channel.SendMessageAsync(
                             text: "Please try again.",
-                            messageReference: message.Reference);
+                            messageReference: messageReference)
+                            .ConfigureAwait(false);
                     break;
 
                     default:
@@ -152,7 +159,8 @@ namespace Reiati.ChillBot.EventHandlers
                 Logger.LogError(e, "Request dropped - exception thrown");
                 await message.Channel.SendMessageAsync(
                     text: "Something went wrong trying to do this for you. File a bug report with Chill Bot.",
-                    messageReference: message.Reference);
+                    messageReference: messageReference)
+                    .ConfigureAwait(false);
             }
             finally
             {


### PR DESCRIPTION
This PR fixes the message reference that is sent with replies from the bot in gild channel messages. As a result, the bot's response will show up as a reply to the original message.

`message.Reference` was previously passed to the `messageReference` parameter in the bot's reply, but that did not produce the described outcome; `message.Reference` is not a reference to the current message but instead is a reference to the message the current message is replying to.

Message references are not currently added to DM responses, but that can be added if desired.