### PR TITLE
Send announcements for opt-in creations, renames, or redescribes

### DIFF
--- a/Behavior/Announce.cs
+++ b/Behavior/Announce.cs
@@ -1,0 +1,131 @@
+﻿using Discord.WebSocket;
+using Reiati.ChillBot.Data;
+using Reiati.ChillBot.Tools;
+using System.Threading.Tasks;
+
+namespace Reiati.ChillBot.Behavior
+{
+    /// <summary>
+    /// Responsible for managing behavior related to making announcements.
+    /// </summary>
+    public class Announce
+    {
+        /// <summary>
+        /// Announces the creation of a channel in the given guild if an annoucement channel is configured.
+        /// </summary>
+        /// <param name="guild">Information about the guild. May not be null.</param>
+        /// <param name="requestAuthor">The author of the channel create request. May not be null.</param>
+        /// <param name="channelName">The name of the new channel. May not be null.</param>
+        /// <param name="channelDescription">The description of the new channel.</param>
+        /// <returns>A task indicating completion.</returns>
+        public static async Task ChannelCreation(
+            Guild guild,
+            SocketGuildUser requestAuthor,
+            string channelName,
+            string channelDescription)
+        {
+            ValidateArg.IsNotNullOrWhiteSpace(channelName, nameof(channelName));
+
+            await Announce.SendAnnouncementMessageAsync(
+                guildConnection: requestAuthor.Guild,
+                guild: guild,
+                message: $"<@{requestAuthor.Id}> created a new channel named **{channelName}** with the description \"{channelDescription}\"\n" +
+                         $"Let me know if you're interested by sending me a message like, \"@Chill Bot join {channelName}\"")
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Annoucees the rename of a channel in the given guild if an annoucement channel is configured.
+        /// </summary>
+        /// <param name="guild">Information about the guild. May not be null.</param>
+        /// <param name="requestAuthor">The author of the channel rename request. May not be null.</param>
+        /// <param name="oldChannelName">The old name of the channel that was renamed. May not be null.</param>
+        /// <param name="newChannelName">The new name of the channel that was renamed. May not be null.</param>
+        /// <returns>A task indicating completion.</returns>
+        public static async Task ChannelRename(
+            Guild guild,
+            SocketGuildUser requestAuthor,
+            string oldChannelName,
+            string newChannelName)
+        {
+            ValidateArg.IsNotNullOrWhiteSpace(oldChannelName, nameof(oldChannelName));
+            ValidateArg.IsNotNullOrWhiteSpace(newChannelName, nameof(newChannelName));
+
+            await Announce.SendAnnouncementMessageAsync(
+                guildConnection: requestAuthor.Guild,
+                guild: guild,
+                message: $"<@{requestAuthor.Id}> changed the name of the **{oldChannelName}** channel to **{newChannelName}**.")
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Announces a change to the description of a channel in the given guild if an annoucement channel is configured.
+        /// </summary>
+        /// <param name="guild">Information about the guild. May not be null.</param>
+        /// <param name="requestAuthor">The author of the channel redescribe request. May not be null.</param>
+        /// <param name="channelName">The name of the channel being described. May not be null.</param>
+        /// <param name="oldDescription">The old description of the channel.</param>
+        /// <param name="newDescription">The new description of the channel.</param>
+        /// <returns>A task indicating completion.</returns>
+        public static async Task ChannelRedescribe(
+            Guild guild,
+            SocketGuildUser requestAuthor,
+            string channelName,
+            string oldDescription,
+            string newDescription)
+        {
+            ValidateArg.IsNotNullOrWhiteSpace(channelName, nameof(channelName));
+
+            await Announce.SendAnnouncementMessageAsync(
+                guildConnection: requestAuthor.Guild,
+                guild: guild,
+                message: $"<@{requestAuthor.Id}> changed the description of the **{channelName}** channel from \"{oldDescription}\" to \"{newDescription}\"")
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Sends a message to the announcement channel if one is configured for the provided guild.
+        /// </summary>
+        /// <param name="guildConnection">The connection to the guild the announcement should be posted in. May not be null.</param>
+        /// <param name="guild">Information about the guild. May not be null.</param>
+        /// <param name="message">The announcement message to send.</param>
+        /// <returns>A task indicating completion.</returns>
+        private static async Task SendAnnouncementMessageAsync(SocketGuild guildConnection, Guild guild, string message)
+        {
+            if (TryGetAnnouncementChannel(guildConnection, guild, out SocketTextChannel announcementChannel))
+            {
+                await announcementChannel.SendMessageAsync(
+                    text: message,
+                    allowedMentions: Discord.AllowedMentions.None)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Try to get the announcement channel configured for the provided guild.
+        /// </summary>
+        /// <param name="guildConnection">The connection to the guild to search for the accounement channel. May not be null.</param>
+        /// <param name="guild">Information about the guild. May not be null.</param>
+        /// <param name="announcementChannel">The announcement channel, if one is configured and exists.</param>
+        /// <returns>Whether the announcement channel was obtained for the provided guild.</returns>
+        private static bool TryGetAnnouncementChannel(SocketGuild guildConnection, Guild guild, out SocketTextChannel announcementChannel)
+        {
+            announcementChannel = default;
+
+            if (guild.AnnouncementChannel.HasValue)
+            {
+                try
+                {
+                    announcementChannel = guildConnection.GetTextChannel(guild.AnnouncementChannel.Value.Value);
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Behavior/OptinChannel.cs
+++ b/Behavior/OptinChannel.cs
@@ -87,6 +87,14 @@ namespace Reiati.ChillBot.Behavior
 
             await requestAuthor.AddRoleAsync(createdRole).ConfigureAwait(false);
 
+            // Annouce the channel creation asynchronously
+            _ = Announce.ChannelCreation(
+                guild: guildData,
+                requestAuthor: requestAuthor,
+                channelName: channelName,
+                channelDescription: description)
+                .ConfigureAwait(false);
+
             return CreateResult.Success;
         }
 
@@ -94,10 +102,10 @@ namespace Reiati.ChillBot.Behavior
         /// Renames an opt-in channel in the given guild.
         /// </summary>
         /// <param name="guildConnection">
-        /// The connection to the guild this channel is being created in. May not be null.
+        /// The connection to the guild this channel is in. May not be null.
         /// </param>
         /// <param name="guildData">Information about this guild. May not be null.</param>
-        /// <param name="requestAuthor">The author of the channel create request. May not be null.</param>
+        /// <param name="requestAuthor">The author of the channel rename request. May not be null.</param>
         /// <param name="currentChannelName">The current name of the channel to rename. May not be null.</param>
         /// <param name="newChannelName">The requested new name of the channel. May not be null.</param>
         /// <returns>The result of the request.</returns>
@@ -153,6 +161,14 @@ namespace Reiati.ChillBot.Behavior
                 settings.Name = newChannelName;
             }).ConfigureAwait(false);
 
+            // Annouce the channel rename asynchronously
+            _ = Announce.ChannelRename(
+                guild: guildData,
+                requestAuthor: requestAuthor,
+                oldChannelName: currentChannelName,
+                newChannelName: newChannelName)
+                .ConfigureAwait(false);
+
             return RenameResult.Success;
         }
 
@@ -160,11 +176,11 @@ namespace Reiati.ChillBot.Behavior
         /// Updates the description of an opt-in channel in the given guild.
         /// </summary>
         /// <param name="guildConnection">
-        /// The connection to the guild this channel is being created in. May not be null.
+        /// The connection to the guild this channel is in. May not be null.
         /// </param>
         /// <param name="guildData">Information about this guild. May not be null.</param>
-        /// <param name="requestAuthor">The author of the channel create request. May not be null.</param>
-        /// <param name="channelName">The current name of the channel to rename. May not be null.</param>
+        /// <param name="requestAuthor">The author of the channel redescribe request. May not be null.</param>
+        /// <param name="channelName">The name of the channel being described. May not be null.</param>
         /// <param name="description">The requested description of the channel.</param>
         /// <returns>The result of the request.</returns>
         public static async Task<UpdateDescriptionResult> UpdateDescription(
@@ -204,10 +220,20 @@ namespace Reiati.ChillBot.Behavior
             }
 
             // Modify the channel description
+            var oldDescription = currentChannel.Topic;
             await currentChannel.ModifyAsync(settings =>
             {
                 settings.Topic = description ?? string.Empty;
             }).ConfigureAwait(false);
+
+            // Annouce the channel description change asynchronously
+            _ = Announce.ChannelRedescribe(
+                guild: guildData,
+                requestAuthor: requestAuthor,
+                channelName: channelName,
+                oldDescription: oldDescription,
+                newDescription: description)
+                .ConfigureAwait(false);
 
             return UpdateDescriptionResult.Success;
         }

--- a/Data/Guild.cs
+++ b/Data/Guild.cs
@@ -40,5 +40,11 @@ namespace Reiati.ChillBot.Data
         /// </summary>
         /// <value>Null if welcome messages are not to be sent.</value>
         public Snowflake? WelcomeChannel { get; set; }
+
+        /// <summary>
+        /// The id representing the channel under which announcement messages are to be sent.
+        /// </summary>
+        /// <value>Null if announcement messages are not to be sent.</value>
+        public Snowflake? AnnouncementChannel { get; set; }
     }
 }

--- a/Data/GuildConverter.cs
+++ b/Data/GuildConverter.cs
@@ -67,6 +67,18 @@ namespace Reiati.ChillBot.Data
                 retVal.WelcomeChannel = welcomeChannelId;
             }
 
+            if (dataObj.TryGetValue(SerializationFields.AnnouncementChannel, out JToken announcementChannel))
+            {
+                if (announcementChannel.Type != JTokenType.Integer)
+                {
+                    throw new InvalidDataException(
+                        $"{SerializationFields.AnnouncementChannel} is expected to be an integer type.");
+                }
+
+                var announcementChannelId = new Snowflake(announcementChannel.ToObject<UInt64>());
+                retVal.AnnouncementChannel = announcementChannelId;
+            }
+
             return retVal;
         }
 
@@ -104,6 +116,13 @@ namespace Reiati.ChillBot.Data
                     new JValue(guild.WelcomeChannel.GetValueOrDefault().Value));
             }
 
+            if (guild.AnnouncementChannel.HasValue)
+            {
+                retVal.Add(
+                    SerializationFields.AnnouncementChannel,
+                    new JValue(guild.AnnouncementChannel.GetValueOrDefault().Value));
+            }
+
             return retVal;
         }
 
@@ -117,6 +136,7 @@ namespace Reiati.ChillBot.Data
             public const string OptinCreatorsRoles = "OptinCreatorsRoles";
             public const string OptinParentCatgory = "OptinParentCatgory";
             public const string WelcomeChannel = "WelcomeChannel";
+            public const string AnnouncementChannel = "AnnouncementChannel";
         }
     }
 }


### PR DESCRIPTION
This PR causes the bot to send announcement messages when changes are made to opt-in channels.
- Add an announcement channel value to the guild repository configuration
- Add an `Announce` behavior used to send announcement message
- If an announcement channel is configured for a guild, send announcement messages when a opt-in channel is created, renamed, or redescribed.

Closes #21, Closes #23