### PR TITLE
Add opt-in updater role for rename/redescribe commands

### DIFF
--- a/Behavior/OptinChannel.cs
+++ b/Behavior/OptinChannel.cs
@@ -117,10 +117,10 @@ namespace Reiati.ChillBot.Behavior
             }
             var optinsCategory = guildData.OptinParentCategory.GetValueOrDefault();
 
-            // Check that the request author has permission to create opt-ins (which means they can rename them as well)
+            // Check that the request author has permission to update opt-ins
             var hasPermission = PermissionsUtilities.HasPermission(
                 userRoles: requestAuthor.Roles.Select(x => new Snowflake(x.Id)),
-                allowedRoles: guildData.OptinCreatorsRoles);
+                allowedRoles: guildData.OptinUpdatersRoles);
             if (!hasPermission)
             {
                 return RenameResult.NoPermissions;
@@ -182,10 +182,10 @@ namespace Reiati.ChillBot.Behavior
             }
             var optinsCategory = guildData.OptinParentCategory.GetValueOrDefault();
 
-            // Check that the request author has permission to create opt-ins (which means they can update their description as well)
+            // Check that the request author has permission to update opt-ins
             var hasPermission = PermissionsUtilities.HasPermission(
                 userRoles: requestAuthor.Roles.Select(x => new Snowflake(x.Id)),
-                allowedRoles: guildData.OptinCreatorsRoles);
+                allowedRoles: guildData.OptinUpdatersRoles);
             if (!hasPermission)
             {
                 return UpdateDescriptionResult.NoPermissions;

--- a/Data/Guild.cs
+++ b/Data/Guild.cs
@@ -30,6 +30,12 @@ namespace Reiati.ChillBot.Data
         public ICollection<Snowflake> OptinCreatorsRoles { get; } = new List<Snowflake>();
 
         /// <summary>
+        /// The ids representing the roles allowed to update opt-in channels.
+        /// </summary>
+        /// <value>Never null.</value>
+        public ICollection<Snowflake> OptinUpdatersRoles { get; } = new List<Snowflake>();
+
+        /// <summary>
         /// The id representing the channel category under which all opt-in channels are to be created.
         /// </summary>
         /// <value>Null if opt-ins are disabled on this server.</value>

--- a/Data/GuildConverter.cs
+++ b/Data/GuildConverter.cs
@@ -43,12 +43,34 @@ namespace Reiati.ChillBot.Data
                 }
             }
 
+            if (dataObj.TryGetValue(SerializationFields.OptinUpdatersRoles, out JToken optinUpdatersRolesToken))
+            {
+                if (optinUpdatersRolesToken.Type != JTokenType.Array)
+                {
+                    throw new InvalidDataException(
+                        $"{SerializationFields.OptinUpdatersRoles} is expected to be an array type.");
+                }
+
+                var optinUpdatersRolesArray = optinUpdatersRolesToken.ToObject<JArray>();
+                foreach (var roleToken in optinUpdatersRolesArray)
+                {
+                    if (roleToken.Type != JTokenType.Integer)
+                    {
+                        throw new InvalidDataException(
+                            $"Each member of {SerializationFields.OptinUpdatersRoles} is expected to be an integer type.");
+                    }
+
+                    var roleId = new Snowflake(roleToken.ToObject<UInt64>());
+                    retVal.OptinUpdatersRoles.Add(roleId);
+                }
+            }
+
             if (dataObj.TryGetValue(SerializationFields.OptinParentCatgory, out JToken optinParentCatgory))
             {
                 if (optinParentCatgory.Type != JTokenType.Integer)
                 {
                     throw new InvalidDataException(
-                        $"{SerializationFields.OptinCreatorsRoles} is expected to be an integer type.");
+                        $"{SerializationFields.OptinParentCatgory} is expected to be an integer type.");
                 }
 
                 var categoryId = new Snowflake(optinParentCatgory.ToObject<UInt64>());
@@ -90,6 +112,17 @@ namespace Reiati.ChillBot.Data
                 retVal.Add(SerializationFields.OptinCreatorsRoles, optinCreatorsRolesArray);
             }
 
+            if (guild.OptinUpdatersRoles.Count > 0)
+            {
+                var optinUpdatersRolesArray = new JArray();
+                foreach (var roleId in guild.OptinUpdatersRoles)
+                {
+                    optinUpdatersRolesArray.Add(new JValue(roleId.Value));
+                }
+
+                retVal.Add(SerializationFields.OptinUpdatersRoles, optinUpdatersRolesArray);
+            }
+
             if (guild.OptinParentCategory.HasValue)
             {
                 retVal.Add(
@@ -115,6 +148,7 @@ namespace Reiati.ChillBot.Data
             // Implementer's note: no need to document fields.
 
             public const string OptinCreatorsRoles = "OptinCreatorsRoles";
+            public const string OptinUpdatersRoles = "OptinUpdatersRoles";
             public const string OptinParentCatgory = "OptinParentCatgory";
             public const string WelcomeChannel = "WelcomeChannel";
         }


### PR DESCRIPTION
This allows guild owners more control over who can rename or redescribe opt-in channels using ChillBot commands.