### PR TITLE
Add support for Discord slash commands, channel change announcements, and opt-in updater role

### DIFF
--- a/Behavior/Announce.cs
+++ b/Behavior/Announce.cs
@@ -1,0 +1,131 @@
+﻿using Discord.WebSocket;
+using Reiati.ChillBot.Data;
+using Reiati.ChillBot.Tools;
+using System.Threading.Tasks;
+
+namespace Reiati.ChillBot.Behavior
+{
+    /// <summary>
+    /// Responsible for managing behavior related to making announcements.
+    /// </summary>
+    public class Announce
+    {
+        /// <summary>
+        /// Announces the creation of a channel in the given guild if an annoucement channel is configured.
+        /// </summary>
+        /// <param name="guild">Information about the guild. May not be null.</param>
+        /// <param name="requestAuthor">The author of the channel create request. May not be null.</param>
+        /// <param name="channelName">The name of the new channel. May not be null.</param>
+        /// <param name="channelDescription">The description of the new channel.</param>
+        /// <returns>A task indicating completion.</returns>
+        public static async Task ChannelCreation(
+            Guild guild,
+            SocketGuildUser requestAuthor,
+            string channelName,
+            string channelDescription)
+        {
+            ValidateArg.IsNotNullOrWhiteSpace(channelName, nameof(channelName));
+
+            await Announce.SendAnnouncementMessageAsync(
+                guildConnection: requestAuthor.Guild,
+                guild: guild,
+                message: $"<@{requestAuthor.Id}> created a new channel named **{channelName}** with the description \"{channelDescription}\"\n" +
+                         $"Let me know if you're interested by sending me a message like, \"@Chill Bot join {channelName}\"")
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Annoucees the rename of a channel in the given guild if an annoucement channel is configured.
+        /// </summary>
+        /// <param name="guild">Information about the guild. May not be null.</param>
+        /// <param name="requestAuthor">The author of the channel rename request. May not be null.</param>
+        /// <param name="oldChannelName">The old name of the channel that was renamed. May not be null.</param>
+        /// <param name="newChannelName">The new name of the channel that was renamed. May not be null.</param>
+        /// <returns>A task indicating completion.</returns>
+        public static async Task ChannelRename(
+            Guild guild,
+            SocketGuildUser requestAuthor,
+            string oldChannelName,
+            string newChannelName)
+        {
+            ValidateArg.IsNotNullOrWhiteSpace(oldChannelName, nameof(oldChannelName));
+            ValidateArg.IsNotNullOrWhiteSpace(newChannelName, nameof(newChannelName));
+
+            await Announce.SendAnnouncementMessageAsync(
+                guildConnection: requestAuthor.Guild,
+                guild: guild,
+                message: $"<@{requestAuthor.Id}> changed the name of the **{oldChannelName}** channel to **{newChannelName}**.")
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Announces a change to the description of a channel in the given guild if an annoucement channel is configured.
+        /// </summary>
+        /// <param name="guild">Information about the guild. May not be null.</param>
+        /// <param name="requestAuthor">The author of the channel redescribe request. May not be null.</param>
+        /// <param name="channelName">The name of the channel being described. May not be null.</param>
+        /// <param name="oldDescription">The old description of the channel.</param>
+        /// <param name="newDescription">The new description of the channel.</param>
+        /// <returns>A task indicating completion.</returns>
+        public static async Task ChannelRedescribe(
+            Guild guild,
+            SocketGuildUser requestAuthor,
+            string channelName,
+            string oldDescription,
+            string newDescription)
+        {
+            ValidateArg.IsNotNullOrWhiteSpace(channelName, nameof(channelName));
+
+            await Announce.SendAnnouncementMessageAsync(
+                guildConnection: requestAuthor.Guild,
+                guild: guild,
+                message: $"<@{requestAuthor.Id}> changed the description of the **{channelName}** channel from \"{oldDescription}\" to \"{newDescription}\"")
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Sends a message to the announcement channel if one is configured for the provided guild.
+        /// </summary>
+        /// <param name="guildConnection">The connection to the guild the announcement should be posted in. May not be null.</param>
+        /// <param name="guild">Information about the guild. May not be null.</param>
+        /// <param name="message">The announcement message to send.</param>
+        /// <returns>A task indicating completion.</returns>
+        private static async Task SendAnnouncementMessageAsync(SocketGuild guildConnection, Guild guild, string message)
+        {
+            if (TryGetAnnouncementChannel(guildConnection, guild, out SocketTextChannel announcementChannel))
+            {
+                await announcementChannel.SendMessageAsync(
+                    text: message,
+                    allowedMentions: Discord.AllowedMentions.None)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Try to get the announcement channel configured for the provided guild.
+        /// </summary>
+        /// <param name="guildConnection">The connection to the guild to search for the accounement channel. May not be null.</param>
+        /// <param name="guild">Information about the guild. May not be null.</param>
+        /// <param name="announcementChannel">The announcement channel, if one is configured and exists.</param>
+        /// <returns>Whether the announcement channel was obtained for the provided guild.</returns>
+        private static bool TryGetAnnouncementChannel(SocketGuild guildConnection, Guild guild, out SocketTextChannel announcementChannel)
+        {
+            announcementChannel = default;
+
+            if (guild.AnnouncementChannel.HasValue)
+            {
+                try
+                {
+                    announcementChannel = guildConnection.GetTextChannel(guild.AnnouncementChannel.Value.Value);
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Behavior/Announce.cs
+++ b/Behavior/Announce.cs
@@ -11,7 +11,7 @@ namespace Reiati.ChillBot.Behavior
     public class Announce
     {
         /// <summary>
-        /// Announces the creation of a channel in the given guild if an annoucement channel is configured.
+        /// Announces the creation of a channel in the given guild if an announcement channel is configured.
         /// </summary>
         /// <param name="guild">Information about the guild. May not be null.</param>
         /// <param name="requestAuthor">The author of the channel create request. May not be null.</param>
@@ -26,16 +26,22 @@ namespace Reiati.ChillBot.Behavior
         {
             ValidateArg.IsNotNullOrWhiteSpace(channelName, nameof(channelName));
 
+            string message = $"<@{requestAuthor.Id}> created a new channel named **{channelName}**";
+            if (!string.IsNullOrWhiteSpace(channelDescription))
+            {
+                message += $" with the description \"{channelDescription}\"";
+            }
+            message += $".\nLet me know if you're interested by using a command like, \"/join {channelName}\"";
+
             await Announce.SendAnnouncementMessageAsync(
                 guildConnection: requestAuthor.Guild,
                 guild: guild,
-                message: $"<@{requestAuthor.Id}> created a new channel named **{channelName}** with the description \"{channelDescription}\"\n" +
-                         $"Let me know if you're interested by using a command like, \"/join {channelName}\"")
+                message: message)
                 .ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Annoucees the rename of a channel in the given guild if an annoucement channel is configured.
+        /// Announces the rename of a channel in the given guild if an announcement channel is configured.
         /// </summary>
         /// <param name="guild">Information about the guild. May not be null.</param>
         /// <param name="requestAuthor">The author of the channel rename request. May not be null.</param>
@@ -59,7 +65,7 @@ namespace Reiati.ChillBot.Behavior
         }
 
         /// <summary>
-        /// Announces a change to the description of a channel in the given guild if an annoucement channel is configured.
+        /// Announces a change to the description of a channel in the given guild if an announcement channel is configured.
         /// </summary>
         /// <param name="guild">Information about the guild. May not be null.</param>
         /// <param name="requestAuthor">The author of the channel redescribe request. May not be null.</param>
@@ -76,10 +82,30 @@ namespace Reiati.ChillBot.Behavior
         {
             ValidateArg.IsNotNullOrWhiteSpace(channelName, nameof(channelName));
 
+            string message = $"<@{requestAuthor.Id}> ";
+
+            if (string.IsNullOrWhiteSpace(newDescription))
+            {
+                message += $"removed the description of the **{channelName}** channel.";
+
+                if (!string.IsNullOrWhiteSpace(oldDescription))
+                {
+                    message += $" The previous description was \"{oldDescription}\"";
+                }
+            }
+            else if (string.IsNullOrWhiteSpace(oldDescription))
+            {
+                message += $"added a description to the **{channelName}** channel: \"{newDescription}\"";
+            }
+            else
+            {
+                message += $"changed the description of the **{channelName}** channel from \"{oldDescription}\" to \"{newDescription}\"";
+            }
+
             await Announce.SendAnnouncementMessageAsync(
                 guildConnection: requestAuthor.Guild,
                 guild: guild,
-                message: $"<@{requestAuthor.Id}> changed the description of the **{channelName}** channel from \"{oldDescription}\" to \"{newDescription}\"")
+                message: message)
                 .ConfigureAwait(false);
         }
 
@@ -104,7 +130,7 @@ namespace Reiati.ChillBot.Behavior
         /// <summary>
         /// Try to get the announcement channel configured for the provided guild.
         /// </summary>
-        /// <param name="guildConnection">The connection to the guild to search for the accounement channel. May not be null.</param>
+        /// <param name="guildConnection">The connection to the guild to search for the announcement channel. May not be null.</param>
         /// <param name="guild">Information about the guild. May not be null.</param>
         /// <param name="announcementChannel">The announcement channel, if one is configured and exists.</param>
         /// <returns>Whether the announcement channel was obtained for the provided guild.</returns>

--- a/Behavior/Announce.cs
+++ b/Behavior/Announce.cs
@@ -30,7 +30,7 @@ namespace Reiati.ChillBot.Behavior
                 guildConnection: requestAuthor.Guild,
                 guild: guild,
                 message: $"<@{requestAuthor.Id}> created a new channel named **{channelName}** with the description \"{channelDescription}\"\n" +
-                         $"Let me know if you're interested by sending me a message like, \"@Chill Bot join {channelName}\"")
+                         $"Let me know if you're interested by using a command like, \"/join {channelName}\"")
                 .ConfigureAwait(false);
         }
 

--- a/Behavior/Help.cs
+++ b/Behavior/Help.cs
@@ -1,3 +1,4 @@
+using Reiati.ChillBot.Commands;
 using System.Collections.Generic;
 
 namespace Reiati.ChillBot.Behavior
@@ -7,6 +8,31 @@ namespace Reiati.ChillBot.Behavior
     /// </summary>
     public class Help
     {
+        /// <summary>
+        /// All of the slash commands this bot recognizes via guild.
+        /// </summary>
+        private static CommandDetails[] guildSlashCommands = new[]
+        {
+            new CommandDetails(
+                $"/{ListOptinCommand.CommandName} {ListOptinCommand.CommandParameters}",
+                ListOptinCommand.CommandDescription),
+            new CommandDetails(
+                $"/{JoinOptinCommand.CommandName} {JoinOptinCommand.CommandParameters}",
+                JoinOptinCommand.CommandDescription),
+            new CommandDetails(
+                $"/{LeaveOptinCommand.CommandName} {LeaveOptinCommand.CommandParameters}",
+                LeaveOptinCommand.CommandDescription),
+            new CommandDetails(
+                $"/{CreateOptinCommand.CommandName} {CreateOptinCommand.CommandParameters}",
+                CreateOptinCommand.CommandDescription),
+            new CommandDetails(
+                $"/{RenameOptinCommand.CommandName} {RenameOptinCommand.CommandParameters}",
+                RenameOptinCommand.CommandDescription),
+            new CommandDetails(
+                $"/{RedescribeOptinCommand.CommandName} {RedescribeOptinCommand.CommandParameters}",
+                RedescribeOptinCommand.CommandDescription),
+        };
+
         /// <summary>
         /// All of the commands this bot recognizes via guild.
         /// </summary>
@@ -38,6 +64,11 @@ namespace Reiati.ChillBot.Behavior
                 "leave opt-in *channel-name*",
                 "Removes you from the channel given.")
         };
+
+        /// <summary>
+        /// All of the slash commands this bot recognizes via guild.
+        /// </summary>
+        public static IReadOnlyCollection<CommandDetails> GuildSlashCommands => guildSlashCommands;
 
         /// <summary>
         /// All of the commands this bot recognizes via guild.

--- a/Behavior/IOptinChannelCacheManager.cs
+++ b/Behavior/IOptinChannelCacheManager.cs
@@ -1,0 +1,25 @@
+﻿using Discord.WebSocket;
+using System.Threading.Tasks;
+
+namespace Reiati.ChillBot.Behavior
+{
+    /// <summary>
+    /// An object that manages a cache of opt-in channel listing results to be checked out and checked in.
+    /// </summary>
+    public interface IOptinChannelCacheManager
+    {
+        /// <summary>
+        /// Retrieves a list of opt-in channels from the cache if present or queries the channels from Discord if they are not already cached.
+        /// </summary>
+        /// <param name="guild">The connection to the guild for querying opt-in channels.</param>
+        /// <param name="recycleResult">A preallocated result that should be returned if passed in.</param>
+        /// <returns>The borrowed opt-in channel list.</returns>
+        Task<OptinChannelCacheResult> GetChannels(SocketGuild guild, OptinChannelCacheResult recycleResult);
+
+        /// <summary>
+        /// Removes the specified guild ID from the cache. It will need to be queried from Discord the next time it is requested.
+        /// </summary>
+        /// <param name="guild">The connection to the guild to remove from the cache.</param>
+        void ClearCache(SocketGuild guild);
+    }
+}

--- a/Behavior/OptinChannel.cs
+++ b/Behavior/OptinChannel.cs
@@ -87,6 +87,14 @@ namespace Reiati.ChillBot.Behavior
 
             await requestAuthor.AddRoleAsync(createdRole).ConfigureAwait(false);
 
+            // Annouce the channel creation asynchronously
+            _ = Announce.ChannelCreation(
+                guild: guildData,
+                requestAuthor: requestAuthor,
+                channelName: channelName,
+                channelDescription: description)
+                .ConfigureAwait(false);
+
             return CreateResult.Success;
         }
 
@@ -94,10 +102,10 @@ namespace Reiati.ChillBot.Behavior
         /// Renames an opt-in channel in the given guild.
         /// </summary>
         /// <param name="guildConnection">
-        /// The connection to the guild this channel is being created in. May not be null.
+        /// The connection to the guild this channel is in. May not be null.
         /// </param>
         /// <param name="guildData">Information about this guild. May not be null.</param>
-        /// <param name="requestAuthor">The author of the channel create request. May not be null.</param>
+        /// <param name="requestAuthor">The author of the channel rename request. May not be null.</param>
         /// <param name="currentChannelName">The current name of the channel to rename. May not be null.</param>
         /// <param name="newChannelName">The requested new name of the channel. May not be null.</param>
         /// <returns>The result of the request.</returns>
@@ -153,6 +161,14 @@ namespace Reiati.ChillBot.Behavior
                 settings.Name = newChannelName;
             }).ConfigureAwait(false);
 
+            // Annouce the channel rename asynchronously
+            _ = Announce.ChannelRename(
+                guild: guildData,
+                requestAuthor: requestAuthor,
+                oldChannelName: currentChannelName,
+                newChannelName: newChannelName)
+                .ConfigureAwait(false);
+
             return RenameResult.Success;
         }
 
@@ -160,11 +176,11 @@ namespace Reiati.ChillBot.Behavior
         /// Updates the description of an opt-in channel in the given guild.
         /// </summary>
         /// <param name="guildConnection">
-        /// The connection to the guild this channel is being created in. May not be null.
+        /// The connection to the guild this channel is in. May not be null.
         /// </param>
         /// <param name="guildData">Information about this guild. May not be null.</param>
-        /// <param name="requestAuthor">The author of the channel create request. May not be null.</param>
-        /// <param name="channelName">The current name of the channel to rename. May not be null.</param>
+        /// <param name="requestAuthor">The author of the channel redescribe request. May not be null.</param>
+        /// <param name="channelName">The name of the channel being described. May not be null.</param>
         /// <param name="description">The requested description of the channel.</param>
         /// <returns>The result of the request.</returns>
         public static async Task<UpdateDescriptionResult> UpdateDescription(
@@ -204,10 +220,20 @@ namespace Reiati.ChillBot.Behavior
             }
 
             // Modify the channel description
+            var oldDescription = currentChannel.Topic;
             await currentChannel.ModifyAsync(settings =>
             {
                 settings.Topic = description ?? string.Empty;
             }).ConfigureAwait(false);
+
+            // Annouce the channel description change asynchronously
+            _ = Announce.ChannelRedescribe(
+                guild: guildData,
+                requestAuthor: requestAuthor,
+                channelName: channelName,
+                oldDescription: oldDescription,
+                newDescription: description)
+                .ConfigureAwait(false);
 
             return UpdateDescriptionResult.Success;
         }

--- a/Behavior/OptinChannel.cs
+++ b/Behavior/OptinChannel.cs
@@ -117,10 +117,10 @@ namespace Reiati.ChillBot.Behavior
             }
             var optinsCategory = guildData.OptinParentCategory.GetValueOrDefault();
 
-            // Check that the request author has permission to create opt-ins (which means they can rename them as well)
+            // Check that the request author has permission to update opt-ins
             var hasPermission = PermissionsUtilities.HasPermission(
                 userRoles: requestAuthor.Roles.Select(x => new Snowflake(x.Id)),
-                allowedRoles: guildData.OptinCreatorsRoles);
+                allowedRoles: guildData.OptinUpdatersRoles);
             if (!hasPermission)
             {
                 return RenameResult.NoPermissions;
@@ -182,10 +182,10 @@ namespace Reiati.ChillBot.Behavior
             }
             var optinsCategory = guildData.OptinParentCategory.GetValueOrDefault();
 
-            // Check that the request author has permission to create opt-ins (which means they can update their description as well)
+            // Check that the request author has permission to update opt-ins
             var hasPermission = PermissionsUtilities.HasPermission(
                 userRoles: requestAuthor.Roles.Select(x => new Snowflake(x.Id)),
-                allowedRoles: guildData.OptinCreatorsRoles);
+                allowedRoles: guildData.OptinUpdatersRoles);
             if (!hasPermission)
             {
                 return UpdateDescriptionResult.NoPermissions;

--- a/Behavior/OptinChannel.cs
+++ b/Behavior/OptinChannel.cs
@@ -13,11 +13,11 @@ namespace Reiati.ChillBot.Behavior
     /// Responsible for managing behavior related to the opt-in channels.
     /// <para>
     /// Opt-in channels are channels which are by default hidden from a user, but are supposed to be advertised to all
-    /// users. By default, a user will not have the role associated with an opt-in channel, but any user may recieve
+    /// users. By default, a user will not have the role associated with an opt-in channel, but any user may receive
     /// the permissions to join that channel.</para>
     /// </summary>
     /// <remarks>
-    /// Opt-in channels must be made under an opt-in category. This category *must* give the bot permisison to view all
+    /// Opt-in channels must be made under an opt-in category. This category *must* give the bot permission to view all
     /// channels, and *should* deny all users from viewing all channels.
     /// </remarks>
     public class OptinChannel
@@ -92,7 +92,7 @@ namespace Reiati.ChillBot.Behavior
 
             await requestAuthor.AddRoleAsync(createdRole).ConfigureAwait(false);
 
-            // Annouce the channel creation asynchronously
+            // Announce the channel creation asynchronously
             _ = Announce.ChannelCreation(
                 guild: guildData,
                 requestAuthor: requestAuthor,
@@ -171,7 +171,7 @@ namespace Reiati.ChillBot.Behavior
                 settings.Name = newChannelName;
             }).ConfigureAwait(false);
 
-            // Annouce the channel rename asynchronously
+            // Announce the channel rename asynchronously
             _ = Announce.ChannelRename(
                 guild: guildData,
                 requestAuthor: requestAuthor,
@@ -241,14 +241,17 @@ namespace Reiati.ChillBot.Behavior
                 settings.Topic = description ?? string.Empty;
             }).ConfigureAwait(false);
 
-            // Annouce the channel description change asynchronously
-            _ = Announce.ChannelRedescribe(
-                guild: guildData,
-                requestAuthor: requestAuthor,
-                channelName: channelName,
-                oldDescription: oldDescription,
-                newDescription: description)
-                .ConfigureAwait(false);
+            if (!string.Equals(oldDescription, description))
+            {
+                // Announce the channel description change asynchronously
+                _ = Announce.ChannelRedescribe(
+                    guild: guildData,
+                    requestAuthor: requestAuthor,
+                    channelName: channelName,
+                    oldDescription: oldDescription,
+                    newDescription: description)
+                    .ConfigureAwait(false);
+            }
 
             return UpdateDescriptionResult.Success;
         }

--- a/Behavior/OptinChannel.cs
+++ b/Behavior/OptinChannel.cs
@@ -32,13 +32,15 @@ namespace Reiati.ChillBot.Behavior
         /// <param name="requestAuthor">The author of the channel create request. May not be null.</param>
         /// <param name="channelName">The requested name of the new channel. May not be null.</param>
         /// <param name="description">The requested description of the new channel.</param>
+        /// <param name="checkPermission">Whether to check if the user has permission to perform this action.</param>
         /// <returns>The result of the request.</returns>
         public static async Task<CreateResult> Create(
             SocketGuild guildConnection,
             Guild guildData,
             SocketGuildUser requestAuthor,
             string channelName,
-            string description)
+            string description,
+            bool checkPermission = true)
         {
             ValidateArg.IsNotNullOrWhiteSpace(channelName, nameof(channelName));
 
@@ -50,12 +52,15 @@ namespace Reiati.ChillBot.Behavior
 
             // TODO: requestAuthor.Roles gets cached. How do I refresh this value so that it's accurate?
 
-            var hasPermission = PermissionsUtilities.HasPermission(
-                userRoles: requestAuthor.Roles.Select(x => new Snowflake(x.Id)),
-                allowedRoles: guildData.OptinCreatorsRoles);
-            if (!hasPermission)
+            if (checkPermission)
             {
-                return CreateResult.NoPermissions;
+                var hasPermission = PermissionsUtilities.HasPermission(
+                    userRoles: requestAuthor.Roles.Select(x => new Snowflake(x.Id)),
+                    allowedRoles: guildData.OptinCreatorsRoles);
+                if (!hasPermission)
+                {
+                    return CreateResult.NoPermissions;
+                }
             }
 
             var optinsCategoryConnection = guildConnection.GetCategoryChannel(optinsCategory.Value);
@@ -108,13 +113,15 @@ namespace Reiati.ChillBot.Behavior
         /// <param name="requestAuthor">The author of the channel rename request. May not be null.</param>
         /// <param name="currentChannelName">The current name of the channel to rename. May not be null.</param>
         /// <param name="newChannelName">The requested new name of the channel. May not be null.</param>
+        /// <param name="checkPermission">Whether to check if the user has permission to perform this action.</param>
         /// <returns>The result of the request.</returns>
         public static async Task<RenameResult> Rename(
             SocketGuild guildConnection,
             Guild guildData,
             SocketGuildUser requestAuthor,
             string currentChannelName,
-            string newChannelName)
+            string newChannelName,
+            bool checkPermission = true)
         {
             ValidateArg.IsNotNullOrWhiteSpace(currentChannelName, nameof(currentChannelName));
             ValidateArg.IsNotNullOrWhiteSpace(newChannelName, nameof(newChannelName));
@@ -125,13 +132,16 @@ namespace Reiati.ChillBot.Behavior
             }
             var optinsCategory = guildData.OptinParentCategory.GetValueOrDefault();
 
-            // Check that the request author has permission to update opt-ins
-            var hasPermission = PermissionsUtilities.HasPermission(
-                userRoles: requestAuthor.Roles.Select(x => new Snowflake(x.Id)),
-                allowedRoles: guildData.OptinUpdatersRoles);
-            if (!hasPermission)
+            if (checkPermission)
             {
-                return RenameResult.NoPermissions;
+                // Check that the request author has permission to update opt-ins
+                var hasPermission = PermissionsUtilities.HasPermission(
+                    userRoles: requestAuthor.Roles.Select(x => new Snowflake(x.Id)),
+                    allowedRoles: guildData.OptinUpdatersRoles);
+                if (!hasPermission)
+                {
+                    return RenameResult.NoPermissions;
+                }
             }
 
             var optinsCategoryConnection = guildConnection.GetCategoryChannel(optinsCategory.Value);
@@ -182,13 +192,15 @@ namespace Reiati.ChillBot.Behavior
         /// <param name="requestAuthor">The author of the channel redescribe request. May not be null.</param>
         /// <param name="channelName">The name of the channel being described. May not be null.</param>
         /// <param name="description">The requested description of the channel.</param>
+        /// <param name="checkPermission">Whether to check if the user has permission to perform this action.</param>
         /// <returns>The result of the request.</returns>
         public static async Task<UpdateDescriptionResult> UpdateDescription(
             SocketGuild guildConnection,
             Guild guildData,
             SocketGuildUser requestAuthor,
             string channelName,
-            string description)
+            string description,
+            bool checkPermission = true)
         {
             ValidateArg.IsNotNullOrWhiteSpace(channelName, nameof(channelName));
 
@@ -198,13 +210,16 @@ namespace Reiati.ChillBot.Behavior
             }
             var optinsCategory = guildData.OptinParentCategory.GetValueOrDefault();
 
-            // Check that the request author has permission to update opt-ins
-            var hasPermission = PermissionsUtilities.HasPermission(
-                userRoles: requestAuthor.Roles.Select(x => new Snowflake(x.Id)),
-                allowedRoles: guildData.OptinUpdatersRoles);
-            if (!hasPermission)
+            if (checkPermission)
             {
-                return UpdateDescriptionResult.NoPermissions;
+                // Check that the request author has permission to update opt-ins
+                var hasPermission = PermissionsUtilities.HasPermission(
+                    userRoles: requestAuthor.Roles.Select(x => new Snowflake(x.Id)),
+                    allowedRoles: guildData.OptinUpdatersRoles);
+                if (!hasPermission)
+                {
+                    return UpdateDescriptionResult.NoPermissions;
+                }
             }
 
             var optinsCategoryConnection = guildConnection.GetCategoryChannel(optinsCategory.Value);

--- a/Behavior/OptinChannelAutocompleteHandler.cs
+++ b/Behavior/OptinChannelAutocompleteHandler.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 namespace Reiati.ChillBot.Behavior
 {
     /// <summary>
-    /// Handles the autocompletion of opt-in channel names.
+    /// Handles the auto-completion of opt-in channel names.
     /// </summary>
     public class OptinChannelAutocompleteHandler : AutocompleteHandler
     {

--- a/Behavior/OptinChannelAutocompleteHandler.cs
+++ b/Behavior/OptinChannelAutocompleteHandler.cs
@@ -1,0 +1,89 @@
+﻿using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+using Reiati.ChillBot.Data;
+using Reiati.ChillBot.Tools;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Reiati.ChillBot.Behavior
+{
+    /// <summary>
+    /// Handles the autocompletion of opt-in channel names.
+    /// </summary>
+    public class OptinChannelAutocompleteHandler : AutocompleteHandler
+    {
+        /// <summary>
+        /// A logger.
+        /// </summary>
+        private ILogger logger;
+
+        /// <summary>
+        /// Cache for opt-in channel details.
+        /// </summary>
+        private IOptinChannelCacheManager optinChannelCache;
+
+        /// <summary>
+        /// Object pool of <see cref="OptinChannelCacheResult"/>s.
+        /// </summary>
+        private static ObjectPool<OptinChannelCacheResult> optinChannelCacheResultPool =
+            new ObjectPool<OptinChannelCacheResult>(
+                tFactory: () => new OptinChannelCacheResult(),
+                preallocate: 3);
+
+        public OptinChannelAutocompleteHandler(ILogger<OptinChannelAutocompleteHandler> logger, IGuildRepository guildRepository, IOptinChannelCacheManager optinChannelCache)
+        {
+            ValidateArg.IsNotNull(logger, nameof(logger));
+            this.logger = logger;
+
+            ValidateArg.IsNotNull(optinChannelCache, nameof(optinChannelCache));
+            this.optinChannelCache = optinChannelCache;
+        }
+
+        public override async Task<AutocompletionResult> GenerateSuggestionsAsync(IInteractionContext context, IAutocompleteInteraction autocompleteInteraction, IParameterInfo parameter, IServiceProvider services)
+        {
+            var optinChannelCacheResult = optinChannelCacheResultPool.Get();
+            try
+            {
+                string userInput = autocompleteInteraction.Data.Current.Value.ToString();
+
+                optinChannelCacheResult = await this.optinChannelCache.GetChannels(context.Guild as SocketGuild, optinChannelCacheResult);
+                switch (optinChannelCacheResult.Result)
+                {
+                    case OptinChannelCacheResult.ResultType.Success:
+                        IEnumerable<AutocompleteResult> results = optinChannelCacheResult.NamesDescriptions
+                            .Where(x => x.name.StartsWith(userInput, StringComparison.InvariantCultureIgnoreCase)) // Only use results that start with user's input
+                            .Select(r => new AutocompleteResult(r.name.Truncate(100), r.name));
+
+                        // Return a maximum of 25 suggestions at a time (API limit)
+                        return AutocompletionResult.FromSuccess(results.Take(25));
+
+                    case OptinChannelCacheResult.ResultType.NoOptinCategory:
+                        return AutocompletionResult.FromError(InteractionCommandError.Unsuccessful, "This server is not set up for opt-in channels.");
+
+                    case OptinChannelCacheResult.ResultType.GuildDoesNotExist:
+                        return AutocompletionResult.FromError(InteractionCommandError.Unsuccessful, "This server has not been configured for Chill Bot yet.");
+
+                    case OptinChannelCacheResult.ResultType.GuildLocked:
+                        return AutocompletionResult.FromError(InteractionCommandError.Unsuccessful, "Please try again.");
+
+                    default:
+                        return AutocompletionResult.FromError(InteractionCommandError.Unsuccessful, optinChannelCacheResult.Result.ToString());
+                }
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError(e, "Autocomplete Request dropped - exception thrown");
+                return AutocompletionResult.FromError(e);
+            }
+            finally
+            {
+                optinChannelCacheResult.ClearReferences();
+                optinChannelCacheResultPool.Return(optinChannelCacheResult);
+            }
+        }
+    }
+}

--- a/Behavior/OptinChannelCacheManager.cs
+++ b/Behavior/OptinChannelCacheManager.cs
@@ -1,0 +1,168 @@
+﻿using Discord.WebSocket;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Reiati.ChillBot.Data;
+using Reiati.ChillBot.HardCoded;
+using Reiati.ChillBot.Tools;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using static Reiati.ChillBot.Behavior.OptinChannel.ListResult;
+
+namespace Reiati.ChillBot.Behavior
+{
+    /// <summary>
+    /// An object that manages a cache of opt-in channel listing results to be checked out and checked in.
+    /// </summary>
+    public class OptinChannelCacheManager : IOptinChannelCacheManager
+    {
+        /// <summary>
+        /// The amount of time channels should be retained in the cache.
+        /// </summary>
+        private readonly TimeSpan cacheLifeTime;
+
+        /// <summary>
+        /// A logger.
+        /// </summary>
+        private ILogger logger;
+
+        /// <summary>
+        /// Cache for opt-in channel names
+        /// </summary>
+        private IOptinChannelCache optinChannelCache;
+
+        /// <summary>
+        /// The repository of <see cref="Guild"/> objects.
+        /// </summary>
+        private IGuildRepository guildRepository;
+
+        /// <summary>
+        /// Object pool of <see cref="FileBasedGuildRepository.CheckoutResult"/>s.
+        /// </summary>
+        private static ObjectPool<GuildCheckoutResult> checkoutResultPool =
+            new ObjectPool<GuildCheckoutResult>(
+                tFactory: () => new GuildCheckoutResult(),
+                preallocate: 3);
+
+        /// <summary>
+        /// Object pool of <see cref="OptinChannel.ListResult"/>s.
+        /// </summary>
+        private static ObjectPool<OptinChannel.ListResult> listResultPool =
+            new ObjectPool<OptinChannel.ListResult>(
+                tFactory: () => new OptinChannel.ListResult(),
+                preallocate: 3);
+
+        /// <summary>
+        /// Constructs a <see cref="OptinChannelCacheManager"/>
+        /// </summary>
+        /// <param name="logger">A logger.</param>
+        /// <param name="configuration">Application configuration.</param>
+        /// <param name="optinChannelCache">The cache manager to use for opt-in channels.</param>
+        /// <param name="guildRepository">The repository used to read and write <see cref="Guild"/>s.</param>
+        public OptinChannelCacheManager(ILogger<OptinChannelCacheManager> logger, IConfiguration configuration, IOptinChannelCache optinChannelCache, IGuildRepository guildRepository)
+        {
+            ValidateArg.IsNotNull(logger, nameof(logger));
+            this.logger = logger;
+
+            ValidateArg.IsNotNull(configuration, nameof(configuration));
+            cacheLifeTime = double.TryParse(configuration[Config.OptinChannelCacheLifeTimeConfigKey], out double lifeTime) ? TimeSpan.FromMinutes(lifeTime) : TimeSpan.FromMinutes(60);
+
+            ValidateArg.IsNotNull(optinChannelCache, nameof(optinChannelCache));
+            this.optinChannelCache = optinChannelCache;
+
+            ValidateArg.IsNotNull(guildRepository, nameof(guildRepository));
+            this.guildRepository = guildRepository;
+        }
+
+        /// <summary>
+        /// Retrieves a list of opt-in channels from the cache if present or queries the channels from Discord if they are not already cached.
+        /// </summary>
+        /// <param name="guild">The connection to the guild for querying opt-in channels.</param>
+        /// <param name="recycleResult">A preallocated result that should be returned if passed in.</param>
+        /// <returns>The borrowed opt-in channel list.</returns>
+        public async Task<OptinChannelCacheResult> GetChannels(SocketGuild guild, OptinChannelCacheResult recycleResult = null)
+        {
+            OptinChannelCacheResult retVal = recycleResult ?? new OptinChannelCacheResult();
+
+            // Try to read from cache first
+            if (!this.optinChannelCache.TryGetValue(guild, out IEnumerable<NameDescription> result))
+            {
+                result = Enumerable.Empty<NameDescription>();
+
+                var checkoutResult = checkoutResultPool.Get();
+                var listResult = listResultPool.Get();
+                try
+                {
+                    checkoutResult = await this.guildRepository.Checkout(guild.Id, checkoutResult);
+                    switch (checkoutResult.Result)
+                    {
+                        case GuildCheckoutResult.ResultType.Success:
+                            using (var borrowedGuild = checkoutResult.BorrowedGuild)
+                            {
+                                borrowedGuild.Commit = false;
+                                var guildData = borrowedGuild.Instance;
+
+                                listResult = OptinChannel.List(guild, guildData, listResult);
+
+                                switch (listResult.Result)
+                                {
+                                    case OptinChannel.ListResult.ResultType.Success:
+                                        result = listResult.NamesDescriptions.ToImmutableArray();
+
+                                        // Cache the results
+                                        this.optinChannelCache.Set(guild, result, this.cacheLifeTime);
+                                        break;
+
+                                    case OptinChannel.ListResult.ResultType.NoOptinCategory:
+                                        retVal.ToNoOptinCategory();
+                                        return retVal;
+
+                                    default:
+                                        throw new NotImplementedException(listResult.Result.ToString());
+                                }
+                            }
+                            break;
+
+                        case GuildCheckoutResult.ResultType.DoesNotExist:
+                            retVal.ToGuildDoesNotExist();
+                            return retVal;
+
+                        case GuildCheckoutResult.ResultType.Locked:
+                            retVal.ToGuildLocked();
+                            return retVal;
+
+                        default:
+                            throw new NotImplementedException(checkoutResult.Result.ToString());
+                    }
+                }
+                catch (Exception e)
+                {
+                    this.logger.LogError(e, "Cached channel request dropped - exception thrown");
+                    throw;
+                }
+                finally
+                {
+                    checkoutResult.ClearReferences();
+                    checkoutResultPool.Return(checkoutResult);
+
+                    listResult.ClearReferences();
+                    listResultPool.Return(listResult);
+                }
+            }
+
+            retVal.ToSuccess(result);
+            return retVal;
+        }
+
+        /// <summary>
+        /// Removes the specified guild ID from the cache. It will need to be queried from Discord the next time it is requested.
+        /// </summary>
+        /// <param name="guild">The connection to the guild to remove from the cache.</param>
+        public void ClearCache(SocketGuild guild)
+        {
+            this.optinChannelCache.Remove(guild);
+        }
+    }
+}

--- a/Behavior/OptinChannelCacheResult.cs
+++ b/Behavior/OptinChannelCacheResult.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using static Reiati.ChillBot.Behavior.OptinChannel.ListResult;
+
+namespace Reiati.ChillBot.Behavior
+{
+    /// <summary>
+    /// The result of a <see cref="OptinChannelCacheManager.GetChannels(Discord.WebSocket.SocketGuild)"/> call.
+    /// </summary>
+    public sealed class OptinChannelCacheResult
+    {
+        /// <summary>
+        /// Underlying list.
+        /// </summary>
+        private readonly List<NameDescription> namesDescriptions = new List<NameDescription>(5);
+
+        /// <summary>
+        /// The type of this result.
+        /// </summary>
+        public ResultType Result { get; private set; }
+
+        /// <summary>
+        /// The names and descriptions of all the opt-in channels.
+        /// </summary>
+        public IReadOnlyList<NameDescription> NamesDescriptions => this.namesDescriptions;
+
+        /// <summary>
+        /// Set this result to the <see cref="ResultType.Success"/> type.
+        /// </summary>
+        /// <param name="namesDescriptions">Names and descriptions of channels.</param>
+        public void ToSuccess(IEnumerable<NameDescription> namesDescriptions)
+        {
+            this.Result = ResultType.Success;
+            this.namesDescriptions.Clear();
+            this.namesDescriptions.AddRange(namesDescriptions);
+        }
+
+        /// <summary>
+        /// Set this result to the <see cref="ResultType.NoOptinCategory"/> type.
+        /// </summary>
+        public void ToNoOptinCategory()
+        {
+            this.Result = ResultType.NoOptinCategory;
+        }
+
+        /// <summary>
+        /// Set this result to the <see cref="ResultType.GuildDoesNotExist"/> type.
+        /// </summary>
+        public void ToGuildDoesNotExist()
+        {
+            this.Result = ResultType.GuildDoesNotExist;
+        }
+
+        /// <summary>
+        /// Set this result to the <see cref="ResultType.GuildLocked"/> type.
+        /// </summary>
+        public void ToGuildLocked()
+        {
+            this.Result = ResultType.GuildLocked;
+        }
+
+        /// <summary>
+        /// Drops all references to objects.
+        /// </summary>
+        /// <remarks>Useful call before returning to a pool.</remarks>
+        public void ClearReferences()
+        {
+            this.namesDescriptions.Clear();
+        }
+
+        /// <summary>
+        /// The result of a <see cref="OptinChannelCacheManager.GetChannels(Discord.WebSocket.SocketGuild)"/> call.
+        /// </summary>
+        public enum ResultType
+        {
+            /// <summary>The channels are able to be retrieved from the cache or Discord API.</summary>
+            Success,
+
+            /// <summary>The server has no Opt-in channel category.</summary>
+            NoOptinCategory,
+
+            /// <summary>No guild was associated with the given guild id.</summary>
+            GuildDoesNotExist,
+
+            /// <summary>This guild is currently in use, try again later.</summary>
+            GuildLocked,
+        }
+    }
+}

--- a/ChillBot.csproj
+++ b/ChillBot.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.1" />
-    <PackageReference Include="Discord.Net" Version="2.3.0" />
+    <PackageReference Include="Discord.Net" Version="3.7.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/ChillBot.csproj
+++ b/ChillBot.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.1" />
     <PackageReference Include="Discord.Net" Version="3.7.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/ChillBot.csproj
+++ b/ChillBot.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.1" />
     <PackageReference Include="Discord.Net" Version="2.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.17.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.21.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Commands/CreateOptinCommand.cs
+++ b/Commands/CreateOptinCommand.cs
@@ -1,0 +1,141 @@
+﻿using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+using Reiati.ChillBot.Behavior;
+using Reiati.ChillBot.Data;
+using Reiati.ChillBot.Tools;
+using System;
+using System.Threading.Tasks;
+using ParameterSummaryAttribute = Discord.Interactions.SummaryAttribute;
+
+namespace Reiati.ChillBot.Commands
+{
+    /// <summary>
+    /// Responsible for handling commands in a guild, related to creating opt-in channels.
+    /// </summary>
+    public class CreateOptinCommand : OptinCommandBase
+    {
+        public const string CommandName = "create";
+        public const string CommandDescription = "Creates a new opt-in channel.";
+        public const string CommandParameters = "*channel-name* *a helpful description of your channel*";
+
+        /// <summary>
+        /// A logger.
+        /// </summary>
+        private ILogger logger;
+
+        /// <summary>
+        /// Cache for opt-in channel details.
+        /// </summary>
+        private IOptinChannelCacheManager optinChannelCache;
+
+        /// <summary>
+        /// Constructs a <see cref="CreateOptinCommand"/>
+        /// </summary>
+        /// <param name="logger">A logger.</param>
+        /// <param name="guildRepository">The repository used to read and write <see cref="Guild"/>s.</param>
+        /// <param name="optinChannelCache">The cache manager to use for opt-in channels.</param>
+        public CreateOptinCommand(ILogger<CreateOptinCommand> logger, IGuildRepository guildRepository, IOptinChannelCacheManager optinChannelCache) : base(guildRepository)
+        {
+            ValidateArg.IsNotNull(logger, nameof(logger));
+            this.logger = logger;
+
+            ValidateArg.IsNotNull(optinChannelCache, nameof(optinChannelCache));
+            this.optinChannelCache = optinChannelCache;
+        }
+
+        /// <summary>
+        /// Slash command to create a opt-in channel.
+        /// </summary>
+        /// <param name="channelName">The name of the channel to create.</param>
+        /// <param name="channelDescription">The description of the channel to create.</param>
+        /// <returns>When the task has completed.</returns>
+        [EnabledInDm(false)]
+        [DefaultMemberPermissions(GuildPermission.ManageChannels)]
+        [SlashCommand(CreateOptinCommand.CommandName, CreateOptinCommand.CommandDescription)]
+        public async Task CreateSlashCommand(
+            [ParameterSummary(description: "The name of the channel to create")] string channelName,
+            [ParameterSummary(description: "The description of the channel to create. Ideally something that explains what it is.")] string channelDescription
+            )
+        {
+            var checkoutResult = checkoutResultPool.Get();
+            try
+            {
+                checkoutResult = await this.guildRepository.Checkout(this.Context.Guild.Id, checkoutResult);
+                switch (checkoutResult.Result)
+                {
+                    case GuildCheckoutResult.ResultType.Success:
+                        using (var borrowedGuild = checkoutResult.BorrowedGuild)
+                        {
+                            var guildData = borrowedGuild.Instance;
+                            var createResult = await OptinChannel.Create(
+                                guildConnection: this.Context.Guild,
+                                guildData: guildData,
+                                requestAuthor: this.Context.User as SocketGuildUser,
+                                channelName: channelName,
+                                description: channelDescription,
+                                checkPermission: false); // Slash commands can have permissions configured by the server admin, so do not perform our own permission check
+                            borrowedGuild.Commit = createResult == OptinChannel.CreateResult.Success;
+
+                            switch (createResult)
+                            {
+                                case OptinChannel.CreateResult.Success:
+                                    // Clear the opt-in channel cache for this guild since a new opt-in channel was created
+                                    this.optinChannelCache.ClearCache(this.Context.Guild);
+
+                                    await this.RespondAsync($"{CreateOptinCommand.SuccessEmoji} New channel created. Enjoy!")
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                case OptinChannel.CreateResult.NoPermissions:
+                                    await this.RespondAsync("You do not have permission to create opt-in channels.",
+                                        ephemeral: true)
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                case OptinChannel.CreateResult.NoOptinCategory:
+                                    await this.RespondAsync("This server is not set up for opt-in channels.")
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                case OptinChannel.CreateResult.ChannelNameUsed:
+                                    await this.RespondAsync("An opt-in channel with this name already exists.",
+                                        ephemeral: true)
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                default:
+                                    throw new NotImplementedException(createResult.ToString());
+                            }
+                        }
+                        break;
+
+                    case GuildCheckoutResult.ResultType.DoesNotExist:
+                        await this.RespondAsync("This server has not been configured for Chill Bot yet.")
+                            .ConfigureAwait(false);
+                        break;
+
+                    case GuildCheckoutResult.ResultType.Locked:
+                        await this.RespondAsync("Please try again.")
+                            .ConfigureAwait(false);
+                        break;
+
+                    default:
+                        throw new NotImplementedException(checkoutResult.Result.ToString());
+                }
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError(e, "Request dropped - exception thrown");
+                await this.RespondAsync("Something went wrong trying to do this for you. File a bug report with Chill Bot.")
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                checkoutResult.ClearReferences();
+                checkoutResultPool.Return(checkoutResult);
+            }
+        }
+    }
+}

--- a/Commands/JoinOptinCommand.cs
+++ b/Commands/JoinOptinCommand.cs
@@ -1,0 +1,127 @@
+﻿using Discord.Interactions;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+using Reiati.ChillBot.Behavior;
+using Reiati.ChillBot.Data;
+using Reiati.ChillBot.Tools;
+using System;
+using System.Threading.Tasks;
+
+namespace Reiati.ChillBot.Commands
+{
+    /// <summary>
+    /// Responsible for handling commands in a guild, related to joining opt-in channels.
+    /// </summary>
+    public class JoinOptinCommand : OptinCommandBase
+    {
+        public const string CommandName = "join";
+        public const string CommandDescription = "Adds you to the opt-in channel given.";
+        public const string CommandParameters = "*channel-name*";
+
+        /// <summary>
+        /// A logger.
+        /// </summary>
+        private ILogger logger;
+
+        /// <summary>
+        /// Constructs a <see cref="JoinOptinCommand"/>
+        /// </summary>
+        /// <param name="logger">A logger.</param>
+        /// <param name="guildRepository">The repository used to read and write <see cref="Guild"/>s.</param>
+        public JoinOptinCommand(ILogger<JoinOptinCommand> logger, IGuildRepository guildRepository) : base(guildRepository)
+        {
+            ValidateArg.IsNotNull(logger, nameof(logger));
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// Slash command to join an opt-in channel.
+        /// </summary>
+        /// <param name="channelName">The name of the channel to join.</param>
+        /// <returns>When the task has completed.</returns>
+        [EnabledInDm(false)]
+        [SlashCommand(JoinOptinCommand.CommandName, JoinOptinCommand.CommandDescription)]
+        public async Task JoinSlashCommand(
+            [Summary(description: "The name of the channel to join"), Autocomplete(typeof(OptinChannelAutocompleteHandler))] string channelName
+            )
+        {
+            var checkoutResult = checkoutResultPool.Get();
+            try
+            {
+                checkoutResult = await this.guildRepository.Checkout(this.Context.Guild.Id, checkoutResult);
+                switch (checkoutResult.Result)
+                {
+                    case GuildCheckoutResult.ResultType.Success:
+                        using (var borrowedGuild = checkoutResult.BorrowedGuild)
+                        {
+                            var guildData = borrowedGuild.Instance;
+                            var joinResult = await OptinChannel.Join(
+                                guildConnection: this.Context.Guild,
+                                guildData: guildData,
+                                requestAuthor: this.Context.User as SocketGuildUser,
+                                channelName: channelName);
+                            borrowedGuild.Commit = joinResult == OptinChannel.JoinResult.Success;
+
+                            switch (joinResult)
+                            {
+                                case OptinChannel.JoinResult.Success:
+                                    await this.RespondAsync($"{JoinOptinCommand.SuccessEmoji} Welcome to {channelName}!")
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                case OptinChannel.JoinResult.NoSuchChannel:
+                                    await this.RespondAsync(
+                                        text: "An opt-in channel with this name does not exist.")
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                case OptinChannel.JoinResult.NoOptinCategory:
+                                    await this.RespondAsync(
+                                        text: "This server is not set up for opt-in channels.")
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                case OptinChannel.JoinResult.RoleMissing:
+                                    await this.RespondAsync(
+                                        text: "The role for this channel went missing. Talk to your server admin.")
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                default:
+                                    throw new NotImplementedException(joinResult.ToString());
+                            }
+                        }
+                        break;
+
+                    case GuildCheckoutResult.ResultType.DoesNotExist:
+                        await this.RespondAsync(
+                            text: "This server has not been configured for Chill Bot yet.")
+                            .ConfigureAwait(false);
+                        break;
+
+                    case GuildCheckoutResult.ResultType.Locked:
+                        await this.RespondAsync(
+                            text: "Please try again.",
+                            ephemeral: true)
+                            .ConfigureAwait(false);
+                        break;
+
+                    default:
+                        throw new NotImplementedException(checkoutResult.Result.ToString());
+                }
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError(e, "Request dropped - exception thrown");
+                await this.RespondAsync(
+                    text: "Something went wrong trying to do this for you. File a bug report with Chill Bot.")
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                checkoutResult.ClearReferences();
+                checkoutResultPool.Return(checkoutResult);
+            }
+        }
+    }
+}

--- a/Commands/LeaveOptinCommand.cs
+++ b/Commands/LeaveOptinCommand.cs
@@ -1,0 +1,142 @@
+﻿using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+using Reiati.ChillBot.Behavior;
+using Reiati.ChillBot.Data;
+using Reiati.ChillBot.Tools;
+using System;
+using System.Threading.Tasks;
+
+namespace Reiati.ChillBot.Commands
+{
+    /// <summary>
+    /// Responsible for handling commands in a guild, related to leaving opt-in channels.
+    /// </summary>
+    public class LeaveOptinCommand : OptinCommandBase
+    {
+        public const string CommandName = "leave";
+        public const string CommandDescription = "Removes you from the channel given.";
+        public const string CommandParameters = "*channel-name*";
+
+        /// <summary>
+        /// A logger.
+        /// </summary>
+        private ILogger logger;
+
+        /// <summary>
+        /// Constructs a <see cref="LeaveOptinCommand"/>
+        /// </summary>
+        /// <param name="logger">A logger.</param>
+        /// <param name="guildRepository">The repository used to read and write <see cref="Guild"/>s.</param>
+        public LeaveOptinCommand(ILogger<LeaveOptinCommand> logger, IGuildRepository guildRepository) : base(guildRepository)
+        {
+            ValidateArg.IsNotNull(logger, nameof(logger));
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// Slash command to leave an opt-in channel.
+        /// </summary>
+        /// <param name="channelName">The name of the channel to leave.</param>
+        /// <returns>When the task has completed.</returns>
+        /// <remarks>
+        /// All responses from the leave command should be ephemeral (private) by default to allow the user to leave the channel silently (without informing other users) if they choose.
+        /// </remarks>
+        [EnabledInDm(false)]
+        [SlashCommand(LeaveOptinCommand.CommandName, LeaveOptinCommand.CommandDescription)]
+        public async Task Leave(
+            [Summary(description: "The name of the channel to leave"), Autocomplete(typeof(OptinChannelAutocompleteHandler))] string channelName
+            )
+        {
+            var checkoutResult = checkoutResultPool.Get();
+            try
+            {
+                checkoutResult = await this.guildRepository.Checkout(this.Context.Guild.Id, checkoutResult)
+                    .ConfigureAwait(false);
+                switch (checkoutResult.Result)
+                {
+                    case GuildCheckoutResult.ResultType.Success:
+                        using (var borrowedGuild = checkoutResult.BorrowedGuild)
+                        {
+                            borrowedGuild.Commit = false;
+                            var guildData = borrowedGuild.Instance;
+
+                            var leaveResult = await OptinChannel.Leave(
+                                guildConnection: this.Context.Guild,
+                                guildData: guildData,
+                                requestAuthor: this.Context.User as SocketGuildUser,
+                                channelName: channelName)
+                                .ConfigureAwait(false);
+
+                            switch (leaveResult)
+                            {
+                                case OptinChannel.LeaveResult.Success:
+                                    await this.RespondAsync($"{LeaveOptinCommand.SuccessEmoji} You have left {channelName}.")
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                case OptinChannel.LeaveResult.NoSuchChannel:
+                                    await this.RespondAsync("There is no opt-in channel with that name. Did you mean something else?")
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                case OptinChannel.LeaveResult.NoOptinCategory:
+                                    await this.RespondAsync("This server is not set up with any opt-in channels right now.")
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                case OptinChannel.LeaveResult.RoleMissing:
+                                    await this.RespondAsync("This channel is not set up correctly. Contact the server admin.")
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                default:
+                                    throw new NotImplementedException(leaveResult.ToString());
+                            }
+                        }
+                        break;
+
+                    case GuildCheckoutResult.ResultType.DoesNotExist:
+                        await this.RespondAsync(
+                            text: "This server has not been configured for Chill Bot yet.")
+                            .ConfigureAwait(false);
+                        break;
+
+                    case GuildCheckoutResult.ResultType.Locked:
+                        await this.RespondAsync(
+                            text: "Please try again.")
+                            .ConfigureAwait(false);
+                        break;
+
+                    default:
+                        throw new NotImplementedException(checkoutResult.Result.ToString());
+                }
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError(e, "Request dropped - exception thrown");
+                await this.RespondAsync(
+                    text: "Something went wrong trying to do this for you. File a bug report with Chill Bot.")
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                checkoutResult.ClearReferences();
+                checkoutResultPool.Return(checkoutResult);
+            }
+        }
+
+        /// <summary>
+        /// Override of the base <see cref="RespondAsync"/> method with the default value of <paramref name="ephemeral"/> changed to <c>true</c>.
+        /// </summary>
+        /// <returns>When the task has completed.</returns>
+        /// <remarks>
+        /// All responses from the leave command should be ephemeral (private) by default to allow the user to leave the channel silently (without informing other users) if they choose.
+        /// </remarks>
+        protected override async Task RespondAsync(string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = true, AllowedMentions allowedMentions = null, RequestOptions options = null, MessageComponent components = null, Embed embed = null)
+        {
+            await base.RespondAsync(text, embeds, isTTS, ephemeral, allowedMentions, options, components, embed).ConfigureAwait(false);
+        }
+    }
+}

--- a/Commands/ListOptinCommand.cs
+++ b/Commands/ListOptinCommand.cs
@@ -68,7 +68,7 @@ namespace Reiati.ChillBot.Commands
                         else
                         {
                             await this.RespondAsync(
-                                text: "This server deosn't have any opt-in channels yet. Try creating one with \"/create channel-name A description of your channel!\"")
+                                text: "This server doesn't have any opt-in channels yet. Try creating one with \"/create channel-name A description of your channel!\"")
                                 .ConfigureAwait(false);
                         }
                         break;

--- a/Commands/ListOptinCommand.cs
+++ b/Commands/ListOptinCommand.cs
@@ -1,0 +1,147 @@
+﻿using Discord.Interactions;
+using Microsoft.Extensions.Logging;
+using Reiati.ChillBot.Behavior;
+using Reiati.ChillBot.Data;
+using Reiati.ChillBot.Tools;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Reiati.ChillBot.Commands
+{
+    /// <summary>
+    /// Responsible for handling commands in a guild, related to listing opt-in channels.
+    /// </summary>
+    public partial class ListOptinCommand : OptinCommandBase
+    {
+        public const string CommandName = "list";
+        public const string CommandDescription = "Lists all of the opt-in channels on this server.";
+        public const string CommandParameters = "";
+
+        /// <summary>
+        /// A logger.
+        /// </summary>
+        private ILogger logger;
+
+        /// <summary>
+        /// Cache for opt-in channel details.
+        /// </summary>
+        private IOptinChannelCacheManager optinChannelCache;
+
+        /// <summary>
+        /// Constructs a <see cref="ListOptinCommand"/>
+        /// </summary>
+        /// <param name="logger">A logger.</param>
+        /// <param name="guildRepository">The repository used to read and write <see cref="Guild"/>s.</param>
+        /// <param name="optinChannelCache">The cache manager to use for opt-in channels.</param>
+        public ListOptinCommand(ILogger<ListOptinCommand> logger, IGuildRepository guildRepository, IOptinChannelCacheManager optinChannelCache) : base(guildRepository)
+        {
+            ValidateArg.IsNotNull(logger, nameof(logger));
+            this.logger = logger;
+
+            ValidateArg.IsNotNull(optinChannelCache, nameof(optinChannelCache));
+            this.optinChannelCache = optinChannelCache;
+        }
+
+        /// <summary>
+        /// Slash command to list available opt-in channels.
+        /// </summary>
+        /// <returns>When the task has completed.</returns>
+        [EnabledInDm(false)]
+        [SlashCommand(ListOptinCommand.CommandName, ListOptinCommand.CommandDescription)]
+        public async Task List()
+        {
+            var optinChannelCacheResult = optinChannelCacheResultPool.Get();
+            try
+            {
+                optinChannelCacheResult = await this.optinChannelCache.GetChannels(this.Context.Guild, optinChannelCacheResult);
+                switch (optinChannelCacheResult.Result)
+                {
+                    case OptinChannelCacheResult.ResultType.Success:
+                        var namesDescriptions = optinChannelCacheResult.NamesDescriptions;
+                        if (namesDescriptions.Count > 0)
+                        {
+                            await this.RespondAsync(
+                                ListOptinCommand.GetListingMessage(namesDescriptions))
+                                .ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            await this.RespondAsync(
+                                text: "This server deosn't have any opt-in channels yet. Try creating one with \"/create channel-name A description of your channel!\"")
+                                .ConfigureAwait(false);
+                        }
+                        break;
+
+                    case OptinChannelCacheResult.ResultType.NoOptinCategory:
+                        await this.RespondAsync(
+                            text: "This server is not set up for opt-in channels.")
+                            .ConfigureAwait(false);
+                        break;
+
+                    case OptinChannelCacheResult.ResultType.GuildDoesNotExist:
+                        await this.RespondAsync(
+                            text: "This server has not been configured for Chill Bot yet.")
+                            .ConfigureAwait(false);
+                        break;
+
+                    case OptinChannelCacheResult.ResultType.GuildLocked:
+                        await this.RespondAsync(
+                            text: "Please try again.")
+                            .ConfigureAwait(false);
+                        break;
+
+                    default:
+                        throw new NotImplementedException(optinChannelCacheResult.Result.ToString());
+                }
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError(e, "Request dropped - exception thrown");
+                await this.RespondAsync(
+                    text: "Something went wrong trying to do this for you. File a bug report with Chill Bot.")
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                optinChannelCacheResult.ClearReferences();
+                optinChannelCacheResultPool.Return(optinChannelCacheResult);
+            }
+        }
+
+        /// <summary>
+        /// Builds a string which enumerates each of the channel names and descriptions.
+        /// </summary>
+        /// <param name="namesDescriptions">Some set of channel names and descriptions.</param>
+        /// <returns>The string which describes them all.</returns>
+        private static string GetListingMessage(IEnumerable<OptinChannel.ListResult.NameDescription> namesDescriptions)
+        {
+            var builder = welcomeMessageBuilderPool.Get();
+            builder.Clear();
+            try
+            {
+                builder.Append("The opt-in channels are:");
+                var lastNameAdded = string.Empty;
+                foreach (var nameDescription in namesDescriptions)
+                {
+                    builder.AppendFormat("\n | **{0}**", nameDescription.name);
+
+                    if (!string.IsNullOrEmpty(nameDescription.description))
+                    {
+                        builder.AppendFormat(" - {0}", nameDescription.description);
+                    }
+
+                    lastNameAdded = nameDescription.name;
+                }
+                builder.AppendFormat(
+                    "\nLet me know if you're interested in any of them by using a command like, \"/join {0}\"",
+                    lastNameAdded);
+                return builder.ToString();
+            }
+            finally
+            {
+                welcomeMessageBuilderPool.Return(builder);
+            }
+        }
+    }
+}

--- a/Commands/OptinCommandBase.cs
+++ b/Commands/OptinCommandBase.cs
@@ -1,0 +1,70 @@
+﻿using Discord;
+using Discord.Interactions;
+using Reiati.ChillBot.Behavior;
+using Reiati.ChillBot.Data;
+using Reiati.ChillBot.Tools;
+using System.Text;
+
+namespace Reiati.ChillBot.Commands
+{
+    /// <summary>
+    /// Base class responsible for handling commands in a guild, related to opt-in channels.
+    /// </summary>
+    public abstract class OptinCommandBase : InteractionModuleBase<ShardedInteractionContext>
+    {
+        #region Pools
+
+        /// <summary>
+        /// Object pool of <see cref="FileBasedGuildRepository.CheckoutResult"/>s.
+        /// </summary>
+        protected static ObjectPool<GuildCheckoutResult> checkoutResultPool =
+            new ObjectPool<GuildCheckoutResult>(
+                tFactory: () => new GuildCheckoutResult(),
+                preallocate: 3);
+
+        /// <summary>
+        /// Object pool of <see cref="OptinChannel.ListResult"/>s.
+        /// </summary>
+        protected static ObjectPool<OptinChannel.ListResult> listResultPool =
+            new ObjectPool<OptinChannel.ListResult>(
+                tFactory: () => new OptinChannel.ListResult(),
+                preallocate: 3);
+
+        /// <summary>
+        /// Object pool of <see cref="OptinChannelCacheResult"/>s.
+        /// </summary>
+        protected static ObjectPool<OptinChannelCacheResult> optinChannelCacheResultPool =
+            new ObjectPool<OptinChannelCacheResult>(
+                tFactory: () => new OptinChannelCacheResult(),
+                preallocate: 3);
+
+        /// <summary>
+        /// Object pool of <see cref="System.Text.StringBuilder"/>s.
+        /// </summary>
+        protected static ObjectPool<StringBuilder> welcomeMessageBuilderPool = new ObjectPool<StringBuilder>(
+            tFactory: () => new StringBuilder(1024),
+            preallocate: 3);
+
+        #endregion Pools
+
+        /// <summary>
+        /// Emoji sent upon successful operation.
+        /// </summary>
+        protected static readonly Emoji SuccessEmoji = new Emoji("✅");
+
+        /// <summary>
+        /// The repository of <see cref="Guild"/> objects.
+        /// </summary>
+        protected IGuildRepository guildRepository;
+
+        /// <summary>
+        /// Constructs a <see cref="OptinCommandBase"/>
+        /// </summary>
+        /// <param name="guildRepository">The repository used to read and write <see cref="Guild"/>s.</param>
+        public OptinCommandBase(IGuildRepository guildRepository)
+        {
+            ValidateArg.IsNotNull(guildRepository, nameof(guildRepository));
+            this.guildRepository = guildRepository;
+        }
+    }
+}

--- a/Commands/RedescribeOptinCommand.cs
+++ b/Commands/RedescribeOptinCommand.cs
@@ -1,0 +1,134 @@
+﻿using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+using Reiati.ChillBot.Behavior;
+using Reiati.ChillBot.Data;
+using Reiati.ChillBot.Tools;
+using System;
+using System.Threading.Tasks;
+
+namespace Reiati.ChillBot.Commands
+{
+    /// <summary>
+    /// Responsible for handling commands in a guild, related to renaming opt-in channels.
+    /// </summary>
+    public class RedescribeOptinCommand : OptinCommandBase
+    {
+        public const string CommandName = "redescribe";
+        public const string CommandDescription = "Changes the description of an existing opt-in channel.";
+        public const string CommandParameters = "*channel-name* *a helpful description of the channel*";
+
+        /// <summary>
+        /// A logger.
+        /// </summary>
+        private ILogger logger;
+
+        /// <summary>
+        /// Cache for opt-in channel details.
+        /// </summary>
+        private IOptinChannelCacheManager optinChannelCache;
+
+        /// <summary>
+        /// Constructs a <see cref="RedescribeOptinCommand"/>
+        /// </summary>
+        /// <param name="logger">A logger.</param>
+        /// <param name="guildRepository">The repository used to read and write <see cref="Guild"/>s.</param>
+        /// <param name="optinChannelCache">The cache manager to use for opt-in channels.</param>
+        public RedescribeOptinCommand(ILogger<RedescribeOptinCommand> logger, IGuildRepository guildRepository, IOptinChannelCacheManager optinChannelCache) : base(guildRepository)
+        {
+            ValidateArg.IsNotNull(logger, nameof(logger));
+            this.logger = logger;
+
+            ValidateArg.IsNotNull(optinChannelCache, nameof(optinChannelCache));
+            this.optinChannelCache = optinChannelCache;
+        }
+
+        [EnabledInDm(false)]
+        [DefaultMemberPermissions(GuildPermission.ManageChannels)]
+        [SlashCommand(RedescribeOptinCommand.CommandName, RedescribeOptinCommand.CommandDescription)]
+        public async Task RedescribeSlashCommand(
+            [Summary(description: "The name of the channel to redescribe"), Autocomplete(typeof(OptinChannelAutocompleteHandler))] string channelName,
+            [Summary(description: "The new description of the channel. Ideally something that explains what it is.")] string newChannelDescription
+            )
+        {
+            var checkoutResult = checkoutResultPool.Get();
+            try
+            {
+                checkoutResult = await this.guildRepository.Checkout(this.Context.Guild.Id, checkoutResult);
+                switch (checkoutResult.Result)
+                {
+                    case GuildCheckoutResult.ResultType.Success:
+                        using (var borrowedGuild = checkoutResult.BorrowedGuild)
+                        {
+                            var guildData = borrowedGuild.Instance;
+                            var updateResult = await OptinChannel.UpdateDescription(
+                                guildConnection: this.Context.Guild,
+                                guildData: guildData,
+                                requestAuthor: this.Context.User as SocketGuildUser,
+                                channelName: channelName,
+                                description: newChannelDescription,
+                                checkPermission: false); // Slash commands can have permissions configured by the server admin outside of the bot, so do not perform our own permission check
+
+                            borrowedGuild.Commit = updateResult == OptinChannel.UpdateDescriptionResult.Success;
+
+                            switch (updateResult)
+                            {
+                                case OptinChannel.UpdateDescriptionResult.Success:
+                                    // Clear the opt-in channel cache for this guild since a opt-in channel was updated
+                                    this.optinChannelCache.ClearCache(this.Context.Guild);
+
+                                    await this.RespondAsync($"{RedescribeOptinCommand.SuccessEmoji} Channel description updated.")
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                case OptinChannel.UpdateDescriptionResult.NoPermissions:
+                                    await this.RespondAsync("You do not have permission to update the description of opt-in channels.",
+                                        ephemeral: true)
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                case OptinChannel.UpdateDescriptionResult.NoOptinCategory:
+                                    await this.RespondAsync("This server is not set up for opt-in channels.")
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                case OptinChannel.UpdateDescriptionResult.NoSuchChannel:
+                                    await this.RespondAsync("An opt-in channel with this name does not exist.")
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                default:
+                                    throw new NotImplementedException(updateResult.ToString());
+                            }
+                        }
+                        break;
+
+                    case GuildCheckoutResult.ResultType.DoesNotExist:
+                        await this.RespondAsync("This server has not been configured for Chill Bot yet.")
+                            .ConfigureAwait(false);
+                        break;
+
+                    case GuildCheckoutResult.ResultType.Locked:
+                        await this.RespondAsync("Please try again.")
+                            .ConfigureAwait(false);
+                        break;
+
+                    default:
+                        throw new NotImplementedException(checkoutResult.Result.ToString());
+                }
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError(e, "Request dropped - exception thrown");
+                await this.RespondAsync("Something went wrong trying to do this for you. File a bug report with Chill Bot.")
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                checkoutResult.ClearReferences();
+                checkoutResultPool.Return(checkoutResult);
+            }
+        }
+    }
+}

--- a/Commands/RenameOptinCommand.cs
+++ b/Commands/RenameOptinCommand.cs
@@ -1,0 +1,140 @@
+﻿using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+using Reiati.ChillBot.Behavior;
+using Reiati.ChillBot.Data;
+using Reiati.ChillBot.Tools;
+using System;
+using System.Threading.Tasks;
+
+namespace Reiati.ChillBot.Commands
+{
+    /// <summary>
+    /// Responsible for handling commands in a guild, related to renaming opt-in channels.
+    /// </summary>
+    public class RenameOptinCommand : OptinCommandBase
+    {
+        public const string CommandName = "rename";
+        public const string CommandDescription = "Changes the name of an existing opt-in channel.";
+        public const string CommandParameters = "*current-channel-name* *new-channel-name*";
+
+        /// <summary>
+        /// A logger.
+        /// </summary>
+        private ILogger logger;
+
+        /// <summary>
+        /// Cache for opt-in channel details.
+        /// </summary>
+        private IOptinChannelCacheManager optinChannelCache;
+
+        /// <summary>
+        /// Constructs a <see cref="RenameOptinCommand"/>
+        /// </summary>
+        /// <param name="logger">A logger.</param>
+        /// <param name="guildRepository">The repository used to read and write <see cref="Guild"/>s.</param>
+        /// <param name="optinChannelCache">The cache manager to use for opt-in channels.</param>
+        public RenameOptinCommand(ILogger<RenameOptinCommand> logger, IGuildRepository guildRepository, IOptinChannelCacheManager optinChannelCache) : base(guildRepository)
+        {
+            ValidateArg.IsNotNull(logger, nameof(logger));
+            this.logger = logger;
+
+            ValidateArg.IsNotNull(optinChannelCache, nameof(optinChannelCache));
+            this.optinChannelCache = optinChannelCache;
+        }
+
+        [EnabledInDm(false)]
+        [DefaultMemberPermissions(GuildPermission.ManageChannels)]
+        [SlashCommand(RenameOptinCommand.CommandName, RenameOptinCommand.CommandDescription)]
+        public async Task RenameSlashCommand(
+            [Summary(description: "The current name of the channel to rename"), Autocomplete(typeof(OptinChannelAutocompleteHandler))] string currentChannelName,
+            [Summary(description: "The new name of the channel")] string newChannelName
+            )
+        {
+            var checkoutResult = checkoutResultPool.Get();
+            try
+            {
+                checkoutResult = await this.guildRepository.Checkout(this.Context.Guild.Id, checkoutResult);
+                switch (checkoutResult.Result)
+                {
+                    case GuildCheckoutResult.ResultType.Success:
+                        using (var borrowedGuild = checkoutResult.BorrowedGuild)
+                        {
+                            var guildData = borrowedGuild.Instance;
+                            var renameResult = await OptinChannel.Rename(
+                                guildConnection: this.Context.Guild,
+                                guildData: guildData,
+                                requestAuthor: this.Context.User as SocketGuildUser,
+                                currentChannelName: currentChannelName,
+                                newChannelName: newChannelName,
+                                checkPermission: false); // Slash commands can have permissions configured by the server admin outside of the bot, so do not perform our own permission check
+
+                            borrowedGuild.Commit = renameResult == OptinChannel.RenameResult.Success;
+
+                            switch (renameResult)
+                            {
+                                case OptinChannel.RenameResult.Success:
+                                    // Clear the opt-in channel cache for this guild since a opt-in channel was updated
+                                    this.optinChannelCache.ClearCache(this.Context.Guild);
+
+                                    await this.RespondAsync($"{RenameOptinCommand.SuccessEmoji} Channel renamed.")
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                case OptinChannel.RenameResult.NoPermissions:
+                                    await this.RespondAsync("You do not have permission to rename opt-in channels.",
+                                        ephemeral: true)
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                case OptinChannel.RenameResult.NoOptinCategory:
+                                    await this.RespondAsync("This server is not set up for opt-in channels.")
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                case OptinChannel.RenameResult.NoSuchChannel:
+                                    await this.RespondAsync("An opt-in channel with this name does not exist.")
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                case OptinChannel.RenameResult.NewChannelNameUsed:
+                                    await this.RespondAsync("An opt-in channel with this new name already exists.",
+                                        ephemeral: true)
+                                        .ConfigureAwait(false);
+                                    break;
+
+                                default:
+                                    throw new NotImplementedException(renameResult.ToString());
+                            }
+                        }
+                        break;
+
+                    case GuildCheckoutResult.ResultType.DoesNotExist:
+                        await this.RespondAsync("This server has not been configured for Chill Bot yet.")
+                            .ConfigureAwait(false);
+                        break;
+
+                    case GuildCheckoutResult.ResultType.Locked:
+                        await this.RespondAsync("Please try again.")
+                            .ConfigureAwait(false);
+                        break;
+
+                    default:
+                        throw new NotImplementedException(checkoutResult.Result.ToString());
+                }
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError(e, "Request dropped - exception thrown");
+                await this.RespondAsync("Something went wrong trying to do this for you. File a bug report with Chill Bot.")
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                checkoutResult.ClearReferences();
+                checkoutResultPool.Return(checkoutResult);
+            }
+        }
+    }
+}

--- a/Data/AzureBlobGuildRepository.cs
+++ b/Data/AzureBlobGuildRepository.cs
@@ -66,7 +66,7 @@ namespace Reiati.ChillBot.Data
                 string blobName = AzureBlobGuildRepository.GetBlobName(guildId);
                 var blobClient = this.blobContainerClient.GetBlockBlobClient(blobName);
 
-                // Aquire a lease on the blob
+                // Acquire a lease on the blob
                 var blobLeaseClient = blobClient.GetBlobLeaseClient();
                 var leaseResult = await blobLeaseClient.AcquireAsync(AzureBlobGuildRepository.BlobLeaseDuration).ConfigureAwait(false);
                 var lease = leaseResult.Value;

--- a/Data/BorrowedT.cs
+++ b/Data/BorrowedT.cs
@@ -9,7 +9,7 @@ namespace Reiati.ChillBot.Data
     public class Borrowed<T> : IDisposable
     {
         /// <summary>
-        /// Arbitrary data provided by the the lender/repository and provided back to it upon return.
+        /// Arbitrary data provided by the lender/repository and provided back to it upon return.
         /// </summary>
         private readonly object data;
 
@@ -23,7 +23,7 @@ namespace Reiati.ChillBot.Data
         /// </summary>
         /// <param name="isntance">The T being borrowed.</param>
         /// <param name="data">
-        /// Arbitrary data provided by the the lender/repository and provided back to it upon return.
+        /// Arbitrary data provided by the lender/repository and provided back to it upon return.
         /// </param>
         /// <param name="onReturn">Arbitrary action invoked upon return.</param>
         public Borrowed(T isntance, object data, Action<T, object, bool> onReturn)

--- a/Data/Guild.cs
+++ b/Data/Guild.cs
@@ -30,6 +30,12 @@ namespace Reiati.ChillBot.Data
         public ICollection<Snowflake> OptinCreatorsRoles { get; } = new List<Snowflake>();
 
         /// <summary>
+        /// The ids representing the roles allowed to update opt-in channels.
+        /// </summary>
+        /// <value>Never null.</value>
+        public ICollection<Snowflake> OptinUpdatersRoles { get; } = new List<Snowflake>();
+
+        /// <summary>
         /// The id representing the channel category under which all opt-in channels are to be created.
         /// </summary>
         /// <value>Null if opt-ins are disabled on this server.</value>

--- a/Data/Guild.cs
+++ b/Data/Guild.cs
@@ -40,5 +40,11 @@ namespace Reiati.ChillBot.Data
         /// </summary>
         /// <value>Null if welcome messages are not to be sent.</value>
         public Snowflake? WelcomeChannel { get; set; }
+
+        /// <summary>
+        /// The id representing the channel under which announcement messages are to be sent.
+        /// </summary>
+        /// <value>Null if announcement messages are not to be sent.</value>
+        public Snowflake? AnnouncementChannel { get; set; }
     }
 }

--- a/Data/GuildConverter.cs
+++ b/Data/GuildConverter.cs
@@ -43,12 +43,34 @@ namespace Reiati.ChillBot.Data
                 }
             }
 
+            if (dataObj.TryGetValue(SerializationFields.OptinUpdatersRoles, out JToken optinUpdatersRolesToken))
+            {
+                if (optinUpdatersRolesToken.Type != JTokenType.Array)
+                {
+                    throw new InvalidDataException(
+                        $"{SerializationFields.OptinUpdatersRoles} is expected to be an array type.");
+                }
+
+                var optinUpdatersRolesArray = optinUpdatersRolesToken.ToObject<JArray>();
+                foreach (var roleToken in optinUpdatersRolesArray)
+                {
+                    if (roleToken.Type != JTokenType.Integer)
+                    {
+                        throw new InvalidDataException(
+                            $"Each member of {SerializationFields.OptinUpdatersRoles} is expected to be an integer type.");
+                    }
+
+                    var roleId = new Snowflake(roleToken.ToObject<UInt64>());
+                    retVal.OptinUpdatersRoles.Add(roleId);
+                }
+            }
+
             if (dataObj.TryGetValue(SerializationFields.OptinParentCatgory, out JToken optinParentCatgory))
             {
                 if (optinParentCatgory.Type != JTokenType.Integer)
                 {
                     throw new InvalidDataException(
-                        $"{SerializationFields.OptinCreatorsRoles} is expected to be an integer type.");
+                        $"{SerializationFields.OptinParentCatgory} is expected to be an integer type.");
                 }
 
                 var categoryId = new Snowflake(optinParentCatgory.ToObject<UInt64>());
@@ -90,6 +112,17 @@ namespace Reiati.ChillBot.Data
                 retVal.Add(SerializationFields.OptinCreatorsRoles, optinCreatorsRolesArray);
             }
 
+            if (guild.OptinUpdatersRoles.Count > 0)
+            {
+                var optinUpdatersRolesArray = new JArray();
+                foreach (var roleId in guild.OptinUpdatersRoles)
+                {
+                    optinUpdatersRolesArray.Add(new JValue(roleId.Value));
+                }
+
+                retVal.Add(SerializationFields.OptinUpdatersRoles, optinUpdatersRolesArray);
+            }
+
             if (guild.OptinParentCategory.HasValue)
             {
                 retVal.Add(
@@ -115,6 +148,7 @@ namespace Reiati.ChillBot.Data
             // Implementer's note: no need to document fields.
 
             public const string OptinCreatorsRoles = "OptinCreatorsRoles";
+            public const string OptinUpdatersRoles = "OptinUpdatersRoles";
             public const string OptinParentCatgory = "OptinParentCatgory";
             public const string WelcomeChannel = "WelcomeChannel";
         }

--- a/Data/GuildConverter.cs
+++ b/Data/GuildConverter.cs
@@ -67,6 +67,18 @@ namespace Reiati.ChillBot.Data
                 retVal.WelcomeChannel = welcomeChannelId;
             }
 
+            if (dataObj.TryGetValue(SerializationFields.AnnouncementChannel, out JToken announcementChannel))
+            {
+                if (announcementChannel.Type != JTokenType.Integer)
+                {
+                    throw new InvalidDataException(
+                        $"{SerializationFields.AnnouncementChannel} is expected to be an integer type.");
+                }
+
+                var announcementChannelId = new Snowflake(announcementChannel.ToObject<UInt64>());
+                retVal.AnnouncementChannel = announcementChannelId;
+            }
+
             return retVal;
         }
 
@@ -104,6 +116,13 @@ namespace Reiati.ChillBot.Data
                     new JValue(guild.WelcomeChannel.GetValueOrDefault().Value));
             }
 
+            if (guild.AnnouncementChannel.HasValue)
+            {
+                retVal.Add(
+                    SerializationFields.AnnouncementChannel,
+                    new JValue(guild.AnnouncementChannel.GetValueOrDefault().Value));
+            }
+
             return retVal;
         }
 
@@ -117,6 +136,7 @@ namespace Reiati.ChillBot.Data
             public const string OptinCreatorsRoles = "OptinCreatorsRoles";
             public const string OptinParentCatgory = "OptinParentCatgory";
             public const string WelcomeChannel = "WelcomeChannel";
+            public const string AnnouncementChannel = "AnnouncementChannel";
         }
     }
 }

--- a/Data/IGuildRepositoryExtensions.cs
+++ b/Data/IGuildRepositoryExtensions.cs
@@ -14,13 +14,13 @@ namespace Reiati.ChillBot.Data
         /// Keeps trying to checkout a guild (with backoff) until either maxTimeout has been hit,
         /// or a value has been returned that's not Locked.
         /// </summary>
-        /// <param name="repo">A repo. May not be null.</param>
+        /// <param name="repository">A repository. May not be null.</param>
         /// <param name="guildId">An id associated with a guild.</param>
         /// <param name="maxTimeout">The maximum amount of time to spend waiting for this to unlock.</param>
         /// <param name="recycleResult">A preallocated result that should be returned if passed in.</param>
         /// <returns>The result.</returns>
         public static async Task<GuildCheckoutResult> WaitForNotLockedCheckout(
-            this IGuildRepository repo,
+            this IGuildRepository repository,
             Snowflake guildId,
             TimeSpan maxTimeout,
             GuildCheckoutResult recycleResult = null)
@@ -30,13 +30,13 @@ namespace Reiati.ChillBot.Data
             TimeSpan nextDelay = TimeSpan.FromMilliseconds(1);
 
             timer.Start();
-            retVal = await repo.Checkout(guildId, retVal);
+            retVal = await repository.Checkout(guildId, retVal);
 
             while (retVal.Result == GuildCheckoutResult.ResultType.Locked
                 && timer.Elapsed + nextDelay < maxTimeout)
             {
                 await Task.Delay(nextDelay);
-                retVal = await repo.Checkout(guildId, retVal);
+                retVal = await repository.Checkout(guildId, retVal);
                 nextDelay *= 1.5;
             }
 

--- a/Data/IOptinChannelCache.cs
+++ b/Data/IOptinChannelCache.cs
@@ -1,0 +1,44 @@
+﻿using Discord.WebSocket;
+using System;
+using System.Collections.Generic;
+using static Reiati.ChillBot.Behavior.OptinChannel.ListResult;
+
+namespace Reiati.ChillBot.Data
+{
+    /// <summary>
+    /// An object that manages a cache of opt-in channels by guild.
+    /// </summary>
+    public interface IOptinChannelCache
+    {
+        /// <summary>
+        /// Try to get the opt-in channels for a guild from the cache.
+        /// </summary>
+        /// <param name="guild">The guild whose opt-in channels should be retrieved from the cache.</param>
+        /// <param name="value">The opt-in channels for the provided <paramref name="guild"/>, if they were present in the cache.</param>
+        /// <returns>Whether the opt-in channels for the guild were present in the cache.</returns>
+        bool TryGetValue(SocketGuild guild, out IEnumerable<NameDescription> value);
+
+        /// <summary>
+        /// Creates or overwrites the specified entry in the cache.
+        /// </summary>
+        /// <param name="guild">The guild whose opt-in channels should be set in the cache.</param>
+        /// <param name="value">The opt-in channels to set in the cache for this guild.</param>
+        /// <returns>The value that was set.</returns>
+        IEnumerable<NameDescription> Set(SocketGuild guild, IEnumerable<NameDescription> value);
+
+        /// <summary>
+        /// Creates or overwrites the specified entry in the cache and sets the value with an absolute expiration date.
+        /// </summary>
+        /// <param name="guild">The guild whose opt-in channels should be set in the cache.</param>
+        /// <param name="value">The opt-in channels to set in the cache for this guild.</param>
+        /// <param name="absoluteExpirationRelativeToNow">The expiration time in absolute terms realtive to the current time.</param>
+        /// <returns>The value that was set.</returns>
+        IEnumerable<NameDescription> Set(SocketGuild guild, IEnumerable<NameDescription> value, TimeSpan absoluteExpirationRelativeToNow);
+
+        /// <summary>
+        /// Removes the channels associated with the given guild from the cache.
+        /// </summary>
+        /// <param name="guild">The guild whose channels to remove from the cache.</param>
+        void Remove(SocketGuild guild);
+    }
+}

--- a/Data/IOptinChannelCache.cs
+++ b/Data/IOptinChannelCache.cs
@@ -31,7 +31,7 @@ namespace Reiati.ChillBot.Data
         /// </summary>
         /// <param name="guild">The guild whose opt-in channels should be set in the cache.</param>
         /// <param name="value">The opt-in channels to set in the cache for this guild.</param>
-        /// <param name="absoluteExpirationRelativeToNow">The expiration time in absolute terms realtive to the current time.</param>
+        /// <param name="absoluteExpirationRelativeToNow">The expiration time in absolute terms relative to the current time.</param>
         /// <returns>The value that was set.</returns>
         IEnumerable<NameDescription> Set(SocketGuild guild, IEnumerable<NameDescription> value, TimeSpan absoluteExpirationRelativeToNow);
 

--- a/Data/OptinChannelMemoryCache.cs
+++ b/Data/OptinChannelMemoryCache.cs
@@ -67,7 +67,7 @@ namespace Reiati.ChillBot.Data
         /// </summary>
         /// <param name="guild">The guild whose opt-in channels should be set in the cache.</param>
         /// <param name="value">The opt-in channels to set in the cache for this guild.</param>
-        /// <param name="absoluteExpirationRelativeToNow">The expiration time in absolute terms realtive to the current time.</param>
+        /// <param name="absoluteExpirationRelativeToNow">The expiration time in absolute terms relative to the current time.</param>
         /// <returns>The value that was set.</returns>
         public IEnumerable<NameDescription> Set(SocketGuild guild, IEnumerable<NameDescription> value, TimeSpan absoluteExpirationRelativeToNow)
         {

--- a/Data/OptinChannelMemoryCache.cs
+++ b/Data/OptinChannelMemoryCache.cs
@@ -1,0 +1,111 @@
+﻿using Discord.WebSocket;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Reiati.ChillBot.Tools;
+using System;
+using System.Collections.Generic;
+using static Reiati.ChillBot.Behavior.OptinChannel.ListResult;
+
+namespace Reiati.ChillBot.Data
+{
+    /// <summary>
+    /// An object that manages a cache of opt-in channels by guild.
+    /// </summary>
+    public class OptinChannelMemoryCache : IOptinChannelCache
+    {
+        /// <summary>
+        /// Memory cache used for caching opt-in channel names
+        /// </summary>
+        private IMemoryCache memoryCache;
+
+        /// <summary>
+        /// Constructs a <see cref="OptinChannelMemoryCache"/>
+        /// </summary>
+        /// <param name="configuration">Application configuration.</param>
+        /// <param name="memoryCache">The memory cache to use for caching opt-in channels.</param>
+        public OptinChannelMemoryCache(IConfiguration configuration, IMemoryCache memoryCache)
+        {
+            ValidateArg.IsNotNull(memoryCache, nameof(memoryCache));
+            this.memoryCache = memoryCache;
+        }
+
+        /// <summary>
+        /// Try to get the opt-in channels for a guild from the cache.
+        /// </summary>
+        /// <param name="guild">The guild whose opt-in channels should be retrieved from the cache.</param>
+        /// <param name="value">The opt-in channels for the provided <paramref name="guild"/>, if they were present in the cache.</param>
+        /// <returns>Whether the opt-in channels for the guild were present in the cache.</returns>
+        public bool TryGetValue(SocketGuild guild, out IEnumerable<NameDescription> value)
+        {
+            if (guild == null)
+            {
+                value = default;
+                return false;
+            }
+
+            return this.memoryCache.TryGetValue(this.GetCacheKey(guild), out value);
+        }
+
+        /// <summary>
+        /// Creates or overwrites the specified entry in the cache.
+        /// </summary>
+        /// <param name="guild">The guild whose opt-in channels should be set in the cache.</param>
+        /// <param name="value">The opt-in channels to set in the cache for this guild.</param>
+        /// <returns>The value that was set.</returns>
+        public IEnumerable<NameDescription> Set(SocketGuild guild, IEnumerable<NameDescription> value)
+        {
+            if (guild == null)
+            {
+                return default;
+            }
+
+            return this.memoryCache.Set(this.GetCacheKey(guild), value);
+        }
+
+        /// <summary>
+        /// Creates or overwrites the specified entry in the cache and sets the value with an absolute expiration date.
+        /// </summary>
+        /// <param name="guild">The guild whose opt-in channels should be set in the cache.</param>
+        /// <param name="value">The opt-in channels to set in the cache for this guild.</param>
+        /// <param name="absoluteExpirationRelativeToNow">The expiration time in absolute terms realtive to the current time.</param>
+        /// <returns>The value that was set.</returns>
+        public IEnumerable<NameDescription> Set(SocketGuild guild, IEnumerable<NameDescription> value, TimeSpan absoluteExpirationRelativeToNow)
+        {
+            if (guild == null)
+            {
+                return default;
+            }
+
+            return this.memoryCache.Set(this.GetCacheKey(guild), value, absoluteExpirationRelativeToNow);
+        }
+
+        /// <summary>
+        /// Removes the channels associated with the given guild from the cache.
+        /// </summary>
+        /// <param name="guild">The guild whose channels to remove from the cache.</param>
+        public void Remove(SocketGuild guild)
+        {
+            if (guild == null)
+            {
+                return;
+            }
+
+            this.memoryCache.Remove(this.GetCacheKey(guild));
+        }
+
+        /// <summary>
+        /// Gets the key used to store the provided guild in the cache.
+        /// </summary>
+        /// <param name="guild">The guild whose key should be returned.</param>
+        /// <returns>The key corresponding to the provided <paramref name="guild"/> in the cache.</returns>
+        protected string GetCacheKey(SocketGuild guild)
+        {
+            if (guild == null)
+            {
+                return default;
+            }
+
+            return nameof(OptinChannelMemoryCache) + "_" + guild.Id.ToString();
+        }
+    }
+}

--- a/Engines/WelcomeMessageEngine.cs
+++ b/Engines/WelcomeMessageEngine.cs
@@ -134,7 +134,7 @@ namespace Reiati.ChillBot.Engines
                         }
                         var exampleChannelName = optinChannelCategory.Channels.Last().Name;
                         builder.AppendFormat(
-                            "\nLet me know if you're interested in any of them by sending me a message like, \"@Chill Bot join {0}\"",
+                            "\nLet me know if you're interested in any of them by using a command like, \"/join {0}\"",
                             exampleChannelName);
                     }
                 }

--- a/EventHandlers/CanHandleResult.cs
+++ b/EventHandlers/CanHandleResult.cs
@@ -68,7 +68,7 @@ namespace Reiati.ChillBot.EventHandlers
             /// <summary>The message was able to be handled.</summary>
             Handleable,
 
-            /// <summary>The message was not abled to be handled.</summary>
+            /// <summary>The message was not able to be handled.</summary>
             Unhandleable,
 
             /// <summary>

--- a/EventHandlers/LeaveOptinDmHandler.cs
+++ b/EventHandlers/LeaveOptinDmHandler.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 namespace Reiati.ChillBot.EventHandlers
 {
     /// <summary>
-    /// Responsible for handling messages in a guild, attempting to list opt-in channels.
+    /// Responsible for handling messages in a guild, attempting to leave opt-in channels.
     /// </summary>
     public class LeaveOptinDmHandler : AbstractRegexHandler
     {

--- a/EventHandlers/ListOptinsGuildHandler.cs
+++ b/EventHandlers/ListOptinsGuildHandler.cs
@@ -163,7 +163,7 @@ namespace Reiati.ChillBot.EventHandlers
                         else
                         {
                             await message.Channel.SendMessageAsync(
-                                text: "This server deosn't have any opt-in channels yet. Try creating one with \"@Chill Bot new opt-in channel-name A description of your channel!\"",
+                                text: "This server doesn't have any opt-in channels yet. Try creating one with \"@Chill Bot new opt-in channel-name A description of your channel!\"",
                                 messageReference: messageReference)
                                 .ConfigureAwait(false);
                         }

--- a/HardCoded/Config.cs
+++ b/HardCoded/Config.cs
@@ -18,6 +18,16 @@ namespace Reiati.ChillBot.HardCoded
         public const string DiscordTokenConfigKey = "DiscordToken";
 
         /// <summary>
+        /// The configuration key of the setting that controls the opt-in channel cache life time.
+        /// </summary>
+        public const string OptinChannelCacheLifeTimeConfigKey = "OptinChannelCacheLifeTimeInMinutes";
+
+        /// <summary>
+        /// The configuration key of the setting that contains the ID of a test guild to be used for debugging.
+        /// </summary>
+        public const string TestGuildIdConfigKey = "TestGuildId";
+
+        /// <summary>
         /// The configuration key of the Application Insights instrumentation key setting.
         /// </summary>
         public const string ApplicationInsightsInstrumentationKeyConfigKey = "ApplicationInsights:InstrumentationKey";

--- a/Manufacturing.md
+++ b/Manufacturing.md
@@ -80,7 +80,7 @@
 ```
 
 # Optional: Deploying to Azure from GitHub Actions
-> This is just one of many ways to deploy the Chill Bot service to Azure. The use of the VMSS platform and the VMSS configuration chosen were primarily motivated by keeping the cost of running the bot minimial.
+> This is just one of many ways to deploy the Chill Bot service to Azure. The use of the VMSS platform and the VMSS configuration chosen were primarily motivated by keeping the cost of running the bot minimal.
 
 ## Prerequisites
 
@@ -149,7 +149,7 @@ Populate the following secrets in your Key Vault:
 
 Store secrets and other parameters for the [Deploy to Azure](./.github/workflows/azure-deploy.yml) action using [GitHub's encrypted secrets](https://docs.github.com/actions/reference/encrypted-secrets).
 
-1. Create an environment in your respository named "Azure" by following [these instructions](https://docs.github.com/actions/reference/environments#creating-an-environment).
+1. Create an environment in your repository named "Azure" by following [these instructions](https://docs.github.com/actions/reference/environments#creating-an-environment).
 2. Populate the following secrets in your "Azure" environment by following [these instructions](https://docs.github.com/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
 
     | Secret          | Where to obtain value     |

--- a/Manufacturing.md
+++ b/Manufacturing.md
@@ -11,7 +11,7 @@
 
 4. Copy your API token to a safe place to use later.
 
-5. Use Discord's [Permissions Calculator](https://discordapi.com/permissions.html#268577872) to create a URL you can use to invite your bot to your own development server. The link provided should already set the permissions correctly for what the bot needs to operate, you just need to enter your Client ID (found in your bot settings.)
+5. Use Discord's [Permissions Calculator](https://discordapi.com/permissions.html#2416061520) to create a URL you can use to invite your bot to your own development server. The link provided should already set the permissions correctly for what the bot needs to operate, you just need to enter your Client ID (found in your bot settings.)
 
 >  Be sure to place the bot's role above any roles you want it to be able to manage in the server (such as channel roles created by a previous instance of Chill Bot). According to [Discord's role hierarchies](https://support.discord.com/hc/articles/214836687-Role-Management-101), "...you can only assign permissions that you have to roles under you." This means the bot will only be able to manage roles sorted below its own role.
 
@@ -33,7 +33,7 @@
 > mkdir guilds
 ```
 
-3. Create and open a new JSON file, the name of which should be the ID of your discord server. (The example below uses notepad as the editor, but any editor will do.)
+3. Create and open a new JSON file, the name of which should be the ID of your Discord server. (The example below uses notepad as the editor, but any editor will do.)
 ```
 > cd guilds
 > notepad 123456789.json
@@ -52,15 +52,12 @@
 
 1. Download and install the .NET Core 3.1 SDK and runtime from [Microsoft](https://dotnet.microsoft.com/download).
 
-2. Make a copy of `log4net.example.xml` and rename it to `log4net.config.xml`. Make any changes to the way logs are displayed here.
-```
-> cp .\log4net.example.xml .\log4net.config.xml
-```
-
-3. Make a copy of `config.json` and rename it to `config.Local.json`. Replace the value of the `DiscordToken` property in this file with your API token.
+2. Make a copy of `config.json` and rename it to `config.Local.json`. Replace the value of the `DiscordToken` property in this file with your API token.
 ```
 > cp .\config.json .\config.Local.json
 ```
+
+3. (Optional) If while testing you would like to register application commands to a test Discord server instead of publishing them globally, edit `config.Local.json` file and add a `TestGuildId` property with a value equal to the ID of your test Discord server. Globally registered commands can take up to one hour to register/update, so it is advised to register your commands to a test Discord server while developing so your changes will take effect immediately.
 
 4. (Optional) If you would like to customize the way logs are displayed, edit the `Logging` section of `config.Local.json` as described [here](https://docs.microsoft.com/dotnet/core/extensions/logging#configure-logging).
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,34 +1,30 @@
 Chill Bot
 =========
 
-A Discord bot which provides opt-in rooms and public invite only rooms.
+A Discord bot which provides opt-in rooms.
 
 A common problem with running a Discord server is that what might have started as a small group chat can turn into a small community of people, many of whom don't know each other. Some people thrive in an environment with large amount of strangers, but others do not, and will start to draw back. I found I was able to get the participation of some of those people back by limiting their audience size. By creating individual rooms that people can join, you can shrink a conversation's audience, without having to purposefully exclude anyone.
 
 ## How It Works
 
-When you invite Chill Bot to your server and configure it appropriately, you can begin creating opt-in channels like so:
+When you invite Chill Bot to your server and configure it appropriately, you can begin creating opt-in channels using [Discord slash commands](https://support.discord.com/hc/articles/1500000368501-Slash-Commands-FAQ) like so:
 
-> @Chill Bot new opt-in donuts This channel is for people who love donuts.
+> /create donuts This channel is for people who love donuts.
 
 Chill Bot will create a new private channel and role associated with that channel. By default, only the channel creator has that role, but other server members can join like so:
 
-> @Chill Bot join donuts
+> /join donuts
 
 When they do this, they will be given the role to view donuts, and just donuts. You can have as many opt-in channels as you want, and each channel will get its own role.
 
 ## How To Use
 In Servers:
- - **@Chill Bot new opt-in \[channel name\] \[channel description\]** - Creates a new opt-in channel, and associated role.
- - **@Chill Bot join \[channel name\]** - Assigns that member the role to view the channel given.
- - **@Chill Bot list opt-ins** - Lists all of the opt-in channels.
- - **@Chill Bot rename opt-in \[current channel name\] \[new channel name\]** - Changes the name of an existing opt-in channel.
- - **@Chill Bot redescribe opt-in \[channel name\] \[channel description\]** - Changes the description of an existing opt-in channel.
- - **@Chill Bot help** - Lists all of the commands available in a server.
-
-In DMs:
- - **leave \[channel name\]** - Removes the role to view the channel given from that user.
- - **help** - Lists all of the commands available in a DM.
+ - **/create \[channel name\] \[channel description\]** - Creates a new opt-in channel, and associated role.
+ - **/join \[channel name\]** - Assigns that member the role to view the channel given.
+ - **/leave \[channel name\]** - Removes the role to view the channel given from that user.
+ - **/list** - Lists all of the opt-in channels.
+ - **/rename \[current channel name\] \[new channel name\]** - Changes the name of an existing opt-in channel.
+ - **/redescribe \[channel name\] \[channel description\]** - Changes the description of an existing opt-in channel.
 
 ## Planned Features
 - [x] Opt-in Channels - Channels which server members can opt into, but are opted out by default.

--- a/Tools/StringExtensions.cs
+++ b/Tools/StringExtensions.cs
@@ -1,0 +1,34 @@
+﻿namespace Reiati.ChillBot.Tools
+{
+    /// <summary>
+    /// Extension methods related to strings.
+    /// </summary>
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Truncates a string to a maximum length.
+        /// </summary>
+        /// <param name="originalString">The string to consider truncating.</param>
+        /// <param name="maxLength">The maximum length of the string.</param>
+        /// <param name="continuationString">A string to append at the end of the truncated string.</param>
+        /// <returns>The truncated string.</returns>
+        public static string Truncate(this string originalString, int maxLength, string continuationString = "...")
+        {
+            if (string.IsNullOrEmpty(originalString) || originalString.Length <= maxLength)
+            {
+                return originalString;
+            }
+
+            int lengthToTakeFromOriginal = maxLength;
+            if (!string.IsNullOrEmpty(continuationString))
+            {
+                lengthToTakeFromOriginal -= continuationString.Length;
+                return originalString.Substring(0, lengthToTakeFromOriginal) + continuationString;
+            }
+            else
+            {
+                return originalString.Substring(0, lengthToTakeFromOriginal);
+            }
+        }
+    }
+}

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
   "DiscordToken": "abcdefghijklmnopqrstuvwxyz",
+  "OptinChannelCacheLifeTimeInMinutes": 60,
   "GuildRepository": {
     "Type": "File"
   },


### PR DESCRIPTION
This PR adds supports for the following features:
 - [Discord slash commands](https://support.discord.com/hc/articles/1500000368501-Slash-Commands-FAQ) (Closes #5)
 - Sending announcements for opt-in creations, renames, or redescribes (Closes #21, Closes #23)
   - This supersedes #25
 - An opt-in updater role for rename/redescribe commands.
   - This supersedes #26

### Slash Commands
The following slash commands have been added to mirror the existing text commands:
 - **/create \[channel name\] \[channel description\]** - Creates a new opt-in channel, and associated role.
 - **/join \[channel name\]** - Assigns that member the role to view the channel given.
 - **/leave \[channel name\]** - Removes the role to view the channel given from that user.
 - **/list** - Lists all of the opt-in channels.
 - **/rename \[current channel name\] \[new channel name\]** - Changes the name of an existing opt-in channel.
 - **/redescribe \[channel name\] \[channel description\]** - Changes the description of an existing opt-in channel.

#### A note on the `/leave` command
A noteworthy change from the existing text commands is that the `/leave` command is implemented as a guild command instead of a DM command. Thanks to [ephemeral messages](https://support.discord.com/hc/articles/1500000580222-Ephemeral-Messages-FAQ), the `/leave` command can still allow users to leave an opt-in channel without making the event noticeable to everyone in the server. Ephemeral messages are private to the user who issued the command (the fact that the command was issued is also private in this case) and will disappear after some time or when the Discord client is restarted.

#### Channel name auto-completion
For any parameter that accepts a channel name, auto-complete has been implemented based on the existing opt-in channel names. To provide better performance for auto-complete, caching of opt-in channel names in memory has been implemented. The cache life time is configurable via a new `OptinChannelCacheLifeTimeInMinutes` setting, but the cache is also cleared any time a bot command is issued that modified the set of opt-ins.

### Channel Change Announcements
The bot can now send announcement messages when changes are made to opt-in channels.
- Add an announcement channel value to the guild repository configuration (`AnnouncementChannel`)
- Add an `Announce` behavior used to send announcement message
- If an announcement channel is configured for a guild, send announcement messages when a opt-in channel is created, renamed, or redescribed.

### Opt-in Updater Role
A new role `OptinUpdatersRoles` in the guild repository configuration allows guild owners more control over who can rename or redescribe opt-in channels using ChillBot commands.
