### PR TITLE
Update to .NET 6 and Ubuntu 22.04

### DIFF
--- a/.deploy/cloud-init.yml
+++ b/.deploy/cloud-init.yml
@@ -8,6 +8,22 @@ packages:
   - unzip
   - dotnet6
 
+# Configure 1/3 of the temporary (ephemeral) disk as swap
+# See https://wiki.ubuntu.com/AzureSwapPartitions for explaination
+disk_setup:
+  ephemeral0:
+    table_type: mbr
+    layout: [66, [33, 82]]
+    overwrite: True
+fs_setup:
+  - device: ephemeral0.1
+    filesystem: ext4
+  - device: ephemeral0.2
+    filesystem: swap
+mounts:
+    - ["ephemeral0.1", "/mnt"]
+    - ["ephemeral0.2", "none", "swap", "sw", "0", "0"]
+
 write_files:
   - path: /home/chillbot/sourceDownloadUrl
     permissions: '0644'

--- a/.deploy/cloud-init.yml
+++ b/.deploy/cloud-init.yml
@@ -6,6 +6,7 @@ users:
 
 packages:
   - unzip
+  - dotnet6
 
 write_files:
   - path: /home/chillbot/sourceDownloadUrl
@@ -39,12 +40,6 @@ write_files:
       dotnet run --configuration Release
 
 runcmd:
-  - wget https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-  - dpkg -i packages-microsoft-prod.deb
-  - apt-get update
-  - apt-get install -y apt-transport-https
-  - apt-get update
-  - apt-get install -y dotnet-sdk-3.1
   - curl -sL https://aka.ms/InstallAzureCLIDeb | bash
   - chown -R chillbot:chillbot /home/chillbot
   - cd /home/chillbot

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -62,7 +62,7 @@ jobs:
             --location "$VMSS_LOCATION" \
             --vm-sku Standard_B1ls \
             --storage-sku Standard_LRS \
-            --image UbuntuLTS \
+            --image Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest \
             --instance-count 1 \
             --disable-overprovision \
             --upgrade-policy-mode automatic \

--- a/ChillBot.csproj
+++ b/ChillBot.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Reiati.ChillBot</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
This change migrates Chill Bot from .NET Core 3.1 to .NET 6 and reduces initial bootstrap time by adding a swap partition.

### .NET 6 Migration
According to https://docs.microsoft.com/lifecycle/products/microsoft-net-and-net-core, support for .NET Core 3.1 will end on December 13, 2022. Support for .NET 6 will last until November 12, 2024.

This migration was also motivated by https://devblogs.microsoft.com/dotnet/dotnet-6-is-now-in-ubuntu-2204/, which means [`dotnet6`](https://packages.ubuntu.com/jammy-updates/dotnet6) can now be installed by listing it in the [cloud-init packages](https://cloudinit.readthedocs.io/en/latest/topics/examples.html#install-arbitrary-packages) and no longer requires explicitly adding/trusting the Microsoft package repository.

### Swap Partition
To improve initial bootstrap performance of the VM, this change also partitions one-third of the VM's temporary (ephemeral) disk as swap by following https://wiki.ubuntu.com/AzureSwapPartitions. On VM SKUs with minimal memory (such as [Standard_B1ls](https://docs.microsoft.com/azure/virtual-machines/sizes-b-series-burstable) used in the [azure-deploy.yml](https://github.com/jamesreiati/chill-bot/blob/main/.github/workflows/azure-deploy.yml#L63) script with only 0.5 GiB of memory), this alleviates memory pressure during the VM initialization phase and reduces the time to have Chill Bot running after a new deployment.