### PR TITLE
Update to Discord.Net 3.8.1 and remove unused gateway intents

### DIFF
--- a/ChillBot.csproj
+++ b/ChillBot.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.1" />
-    <PackageReference Include="Discord.Net" Version="3.7.2" />
+    <PackageReference Include="Discord.Net" Version="3.8.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.21.0" />

--- a/Program.cs
+++ b/Program.cs
@@ -125,7 +125,7 @@ namespace Reiati.ChillBot
                     {
                         TotalShards = 1,
                         LogLevel = Program.GetMinimumDiscordLogLevel(host.Configuration).ToLogSeverity(),
-                        GatewayIntents = GatewayIntents.AllUnprivileged | GatewayIntents.GuildMembers
+                        GatewayIntents = (GatewayIntents.AllUnprivileged | GatewayIntents.GuildMembers) ^ (GatewayIntents.GuildScheduledEvents | GatewayIntents.GuildInvites)
                     };
 
                     services.AddSingleton(socketConfig);


### PR DESCRIPTION
Discord.Net version 3.8.1 includes a fix for https://github.com/discord-net/Discord.Net/issues/2461.

Now that warnings are being properly reported, this change also removes some unused gateway intents that would otherwise cause warnings to be logged.