### PR TITLE
Link to the /join slash command in messages

### DIFF
--- a/Behavior/Announce.cs
+++ b/Behavior/Announce.cs
@@ -1,4 +1,5 @@
 ﻿using Discord.WebSocket;
+using Reiati.ChillBot.Commands;
 using Reiati.ChillBot.Data;
 using Reiati.ChillBot.Tools;
 using System.Threading.Tasks;
@@ -17,21 +18,28 @@ namespace Reiati.ChillBot.Behavior
         /// <param name="requestAuthor">The author of the channel create request. May not be null.</param>
         /// <param name="channelName">The name of the new channel. May not be null.</param>
         /// <param name="channelDescription">The description of the new channel.</param>
+        /// <param name="joinCommandLink">An optional link to the join command that can be used to join the new channel.</param>
         /// <returns>A task indicating completion.</returns>
         public static async Task ChannelCreation(
             Guild guild,
             SocketGuildUser requestAuthor,
             string channelName,
-            string channelDescription)
+            string channelDescription,
+            string joinCommandLink = null)
         {
             ValidateArg.IsNotNullOrWhiteSpace(channelName, nameof(channelName));
+
+            if (string.IsNullOrEmpty(joinCommandLink))
+            {
+                joinCommandLink = "/" + JoinOptinCommand.CommandName;
+            }
 
             string message = $"<@{requestAuthor.Id}> created a new channel named **{channelName}**";
             if (!string.IsNullOrWhiteSpace(channelDescription))
             {
                 message += $" with the description \"{channelDescription}\"";
             }
-            message += $".\nLet me know if you're interested by using a command like, \"/join {channelName}\"";
+            message += $".\nLet me know if you're interested by using a command like, \"{joinCommandLink} {channelName}\"";
 
             await Announce.SendAnnouncementMessageAsync(
                 guildConnection: requestAuthor.Guild,

--- a/Behavior/OptinChannel.cs
+++ b/Behavior/OptinChannel.cs
@@ -33,6 +33,7 @@ namespace Reiati.ChillBot.Behavior
         /// <param name="channelName">The requested name of the new channel. May not be null.</param>
         /// <param name="description">The requested description of the new channel.</param>
         /// <param name="checkPermission">Whether to check if the user has permission to perform this action.</param>
+        /// <param name="joinCommandLink">An optional link to the join command that can be used to join the new channel.</param>
         /// <returns>The result of the request.</returns>
         public static async Task<CreateResult> Create(
             SocketGuild guildConnection,
@@ -40,7 +41,8 @@ namespace Reiati.ChillBot.Behavior
             SocketGuildUser requestAuthor,
             string channelName,
             string description,
-            bool checkPermission = true)
+            bool checkPermission = true,
+            string joinCommandLink = null)
         {
             ValidateArg.IsNotNullOrWhiteSpace(channelName, nameof(channelName));
 
@@ -97,7 +99,8 @@ namespace Reiati.ChillBot.Behavior
                 guild: guildData,
                 requestAuthor: requestAuthor,
                 channelName: channelName,
-                channelDescription: description)
+                channelDescription: description,
+                joinCommandLink: joinCommandLink)
                 .ConfigureAwait(false);
 
             return CreateResult.Success;

--- a/Data/GuildMemoryCache.cs
+++ b/Data/GuildMemoryCache.cs
@@ -1,0 +1,99 @@
+﻿using Discord.WebSocket;
+using Microsoft.Extensions.Caching.Memory;
+using Reiati.ChillBot.Tools;
+using System;
+
+namespace Reiati.ChillBot.Data
+{
+    /// <summary>
+    /// An object that manages a cache of <typeparamref name="TItem"/> by guild.
+    /// </summary>
+    public abstract class GuildMemoryCache<TItem> : IGuildCache<TItem>
+    {
+        /// <summary>
+        /// Memory cache used for caching a <typeparamref name="TItem"/> per guild.
+        /// </summary>
+        protected IMemoryCache memoryCache;
+
+        /// <summary>
+        /// Constructs a <see cref="GuildMemoryCache<T>"/>
+        /// </summary>
+        /// <param name="memoryCache">The memory cache to use for caching a <typeparamref name="TItem"/> per guild.</param>
+        public GuildMemoryCache(IMemoryCache memoryCache)
+        {
+            ValidateArg.IsNotNull(memoryCache, nameof(memoryCache));
+            this.memoryCache = memoryCache;
+        }
+
+        /// <summary>
+        /// Try to get the <typeparamref name="TItem"/> for a guild from the cache.
+        /// </summary>
+        /// <param name="guild">The guild whose <typeparamref name="TItem"/> should be retrieved from the cache.</param>
+        /// <param name="value">The <typeparamref name="TItem"/> for the provided <paramref name="guild"/>, if it was present in the cache.</param>
+        /// <returns>Whether the <typeparamref name="TItem"/> for the guild was present in the cache.</returns>
+        public virtual bool TryGetValue(SocketGuild guild, out TItem value)
+        {
+            if (guild == null)
+            {
+                value = default;
+                return false;
+            }
+
+            return this.memoryCache.TryGetValue(this.GetCacheKey(guild), out value);
+        }
+
+        /// <summary>
+        /// Creates or overwrites the specified entry in the cache.
+        /// </summary>
+        /// <param name="guild">The guild whose <typeparamref name="TItem"/> should be set in the cache.</param>
+        /// <param name="value">The <typeparamref name="TItem"/> to set in the cache for this guild.</param>
+        /// <returns>The value that was set.</returns>
+        public virtual TItem Set(SocketGuild guild, TItem value)
+        {
+            if (guild == null)
+            {
+                return default;
+            }
+
+            return this.memoryCache.Set(this.GetCacheKey(guild), value);
+        }
+
+        /// <summary>
+        /// Creates or overwrites the specified entry in the cache and sets the value with an absolute expiration date.
+        /// </summary>
+        /// <param name="guild">The guild whose <typeparamref name="TItem"/> should be set in the cache.</param>
+        /// <param name="value">The <typeparamref name="TItem"/> to set in the cache for this guild.</param>
+        /// <param name="absoluteExpirationRelativeToNow">The expiration time in absolute terms relative to the current time.</param>
+        /// <returns>The value that was set.</returns>
+        public virtual TItem Set(SocketGuild guild, TItem value, TimeSpan absoluteExpirationRelativeToNow)
+        {
+            if (guild == null)
+            {
+                return default;
+            }
+
+            return this.memoryCache.Set(this.GetCacheKey(guild), value, absoluteExpirationRelativeToNow);
+        }
+
+        /// <summary>
+        /// Removes the <typeparamref name="TItem"/> associated with the given guild from the cache.
+        /// </summary>
+        /// <param name="guild">The guild whose <typeparamref name="TItem"/> should be remove from the cache.</param>
+        public virtual void Remove(SocketGuild guild)
+        {
+            if (guild == null)
+            {
+                return;
+            }
+
+            this.memoryCache.Remove(this.GetCacheKey(guild));
+        }
+
+        /// <summary>
+        /// Gets the key used to store the provided guild in the cache.
+        /// </summary>
+        /// <param name="guild">The guild whose key should be returned.</param>
+        /// <returns>The key corresponding to the provided <paramref name="guild"/> in the cache.</returns>
+        protected abstract string GetCacheKey(SocketGuild guild);
+    }
+}

--- a/Data/IGuildCache.cs
+++ b/Data/IGuildCache.cs
@@ -1,0 +1,42 @@
+﻿using Discord.WebSocket;
+using System;
+
+namespace Reiati.ChillBot.Data
+{
+    /// <summary>
+    /// An object that manages a cache of <typeparamref name="TItem"/> by guild.
+    /// </summary>
+    public interface IGuildCache<TItem>
+    {
+        /// <summary>
+        /// Try to get the <typeparamref name="TItem"/> for a guild from the cache.
+        /// </summary>
+        /// <param name="guild">The guild whose <typeparamref name="TItem"/> should be retrieved from the cache.</param>
+        /// <param name="value">The <typeparamref name="TItem"/> for the provided <paramref name="guild"/>, if it was present in the cache.</param>
+        /// <returns>Whether the <typeparamref name="TItem"/> for the guild were present in the cache.</returns>
+        bool TryGetValue(SocketGuild guild, out TItem value);
+
+        /// <summary>
+        /// Creates or overwrites the specified entry in the cache.
+        /// </summary>
+        /// <param name="guild">The guild whose <typeparamref name="TItem"/> should be set in the cache.</param>
+        /// <param name="value">The <typeparamref name="TItem"/> to set in the cache for this guild.</param>
+        /// <returns>The value that was set.</returns>
+        TItem Set(SocketGuild guild, TItem value);
+
+        /// <summary>
+        /// Creates or overwrites the specified entry in the cache and sets the value with an absolute expiration date.
+        /// </summary>
+        /// <param name="guild">The guild whose <typeparamref name="TItem"/> should be set in the cache.</param>
+        /// <param name="value">The <typeparamref name="TItem"/> to set in the cache for this guild.</param>
+        /// <param name="absoluteExpirationRelativeToNow">The expiration time in absolute terms relative to the current time.</param>
+        /// <returns>The value that was set.</returns>
+        TItem Set(SocketGuild guild, TItem value, TimeSpan absoluteExpirationRelativeToNow);
+
+        /// <summary>
+        /// Removes the <typeparamref name="TItem"/> associated with the given guild from the cache.
+        /// </summary>
+        /// <param name="guild">The guild whose channels to remove from the cache.</param>
+        void Remove(SocketGuild guild);
+    }
+}

--- a/Data/IOptinChannelCache.cs
+++ b/Data/IOptinChannelCache.cs
@@ -1,6 +1,4 @@
-﻿using Discord.WebSocket;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using static Reiati.ChillBot.Behavior.OptinChannel.ListResult;
 
 namespace Reiati.ChillBot.Data
@@ -8,37 +6,7 @@ namespace Reiati.ChillBot.Data
     /// <summary>
     /// An object that manages a cache of opt-in channels by guild.
     /// </summary>
-    public interface IOptinChannelCache
+    public interface IOptinChannelCache : IGuildCache<IEnumerable<NameDescription>>
     {
-        /// <summary>
-        /// Try to get the opt-in channels for a guild from the cache.
-        /// </summary>
-        /// <param name="guild">The guild whose opt-in channels should be retrieved from the cache.</param>
-        /// <param name="value">The opt-in channels for the provided <paramref name="guild"/>, if they were present in the cache.</param>
-        /// <returns>Whether the opt-in channels for the guild were present in the cache.</returns>
-        bool TryGetValue(SocketGuild guild, out IEnumerable<NameDescription> value);
-
-        /// <summary>
-        /// Creates or overwrites the specified entry in the cache.
-        /// </summary>
-        /// <param name="guild">The guild whose opt-in channels should be set in the cache.</param>
-        /// <param name="value">The opt-in channels to set in the cache for this guild.</param>
-        /// <returns>The value that was set.</returns>
-        IEnumerable<NameDescription> Set(SocketGuild guild, IEnumerable<NameDescription> value);
-
-        /// <summary>
-        /// Creates or overwrites the specified entry in the cache and sets the value with an absolute expiration date.
-        /// </summary>
-        /// <param name="guild">The guild whose opt-in channels should be set in the cache.</param>
-        /// <param name="value">The opt-in channels to set in the cache for this guild.</param>
-        /// <param name="absoluteExpirationRelativeToNow">The expiration time in absolute terms relative to the current time.</param>
-        /// <returns>The value that was set.</returns>
-        IEnumerable<NameDescription> Set(SocketGuild guild, IEnumerable<NameDescription> value, TimeSpan absoluteExpirationRelativeToNow);
-
-        /// <summary>
-        /// Removes the channels associated with the given guild from the cache.
-        /// </summary>
-        /// <param name="guild">The guild whose channels to remove from the cache.</param>
-        void Remove(SocketGuild guild);
     }
 }

--- a/Data/ISlashCommandCache.cs
+++ b/Data/ISlashCommandCache.cs
@@ -1,0 +1,12 @@
+﻿using Discord.Interactions;
+using System.Collections.Generic;
+
+namespace Reiati.ChillBot.Data
+{
+    /// <summary>
+    /// An object that manages a cache of slash command information by guild.
+    /// </summary>
+    public interface ISlashCommandCache : IGuildCache<IReadOnlyDictionary<SlashCommandInfo, SlashCommand>>
+    {
+    }
+}

--- a/Data/ISlashCommandCacheManager.cs
+++ b/Data/ISlashCommandCacheManager.cs
@@ -1,0 +1,28 @@
+﻿using Discord.WebSocket;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Reiati.ChillBot.Data
+{
+    /// <summary>
+    /// An object that manages a cache of slash commands by guild.
+    /// </summary>
+    public interface ISlashCommandCacheManager
+    {
+        /// <summary>
+        /// Retrieves a dictionary of slash commands from the cache if present or queries the slash commands from Discord if they are not already cached.
+        /// </summary>
+        /// <param name="guild">The connection to the guild for querying slash commands.</param>
+        /// <returns>The slash command information for the guild.</returns>
+        Task<IReadOnlyCollection<SlashCommand>> GetAllSlashCommandsAsync(SocketGuild guild);
+
+        /// <summary>
+        /// Retrieves information about a specific slash command from the cache if present or queries the slash command from Discord if it is not already cached.
+        /// </summary>
+        /// <typeparam name="TModule">Declaring module type of this slash command, must be a type of <see cref="Discord.Interactions.InteractionModuleBase"/>.</typeparam>
+        /// <param name="guild">The connection to the guild for querying slash commands.</param>
+        /// <param name="methodName">Method name of the slash command handler, use of <see cref="nameof"/> is recommended.</param>
+        /// <returns>The slash command information for the guild.</returns>
+        Task<SlashCommand> GetSlashCommandInfoAsync<TModule>(SocketGuild guild, string methodName) where TModule : class;
+    }
+}

--- a/Data/OptinChannelMemoryCache.cs
+++ b/Data/OptinChannelMemoryCache.cs
@@ -1,8 +1,5 @@
 ﻿using Discord.WebSocket;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Configuration;
-using Reiati.ChillBot.Tools;
-using System;
 using System.Collections.Generic;
 using static Reiati.ChillBot.Behavior.OptinChannel.ListResult;
 
@@ -11,86 +8,14 @@ namespace Reiati.ChillBot.Data
     /// <summary>
     /// An object that manages a cache of opt-in channels by guild.
     /// </summary>
-    public class OptinChannelMemoryCache : IOptinChannelCache
+    public class OptinChannelMemoryCache : GuildMemoryCache<IEnumerable<NameDescription>>, IOptinChannelCache
     {
-        /// <summary>
-        /// Memory cache used for caching opt-in channel names
-        /// </summary>
-        private IMemoryCache memoryCache;
-
         /// <summary>
         /// Constructs a <see cref="OptinChannelMemoryCache"/>
         /// </summary>
-        /// <param name="configuration">Application configuration.</param>
         /// <param name="memoryCache">The memory cache to use for caching opt-in channels.</param>
-        public OptinChannelMemoryCache(IConfiguration configuration, IMemoryCache memoryCache)
+        public OptinChannelMemoryCache(IMemoryCache memoryCache) : base(memoryCache)
         {
-            ValidateArg.IsNotNull(memoryCache, nameof(memoryCache));
-            this.memoryCache = memoryCache;
-        }
-
-        /// <summary>
-        /// Try to get the opt-in channels for a guild from the cache.
-        /// </summary>
-        /// <param name="guild">The guild whose opt-in channels should be retrieved from the cache.</param>
-        /// <param name="value">The opt-in channels for the provided <paramref name="guild"/>, if they were present in the cache.</param>
-        /// <returns>Whether the opt-in channels for the guild were present in the cache.</returns>
-        public bool TryGetValue(SocketGuild guild, out IEnumerable<NameDescription> value)
-        {
-            if (guild == null)
-            {
-                value = default;
-                return false;
-            }
-
-            return this.memoryCache.TryGetValue(this.GetCacheKey(guild), out value);
-        }
-
-        /// <summary>
-        /// Creates or overwrites the specified entry in the cache.
-        /// </summary>
-        /// <param name="guild">The guild whose opt-in channels should be set in the cache.</param>
-        /// <param name="value">The opt-in channels to set in the cache for this guild.</param>
-        /// <returns>The value that was set.</returns>
-        public IEnumerable<NameDescription> Set(SocketGuild guild, IEnumerable<NameDescription> value)
-        {
-            if (guild == null)
-            {
-                return default;
-            }
-
-            return this.memoryCache.Set(this.GetCacheKey(guild), value);
-        }
-
-        /// <summary>
-        /// Creates or overwrites the specified entry in the cache and sets the value with an absolute expiration date.
-        /// </summary>
-        /// <param name="guild">The guild whose opt-in channels should be set in the cache.</param>
-        /// <param name="value">The opt-in channels to set in the cache for this guild.</param>
-        /// <param name="absoluteExpirationRelativeToNow">The expiration time in absolute terms relative to the current time.</param>
-        /// <returns>The value that was set.</returns>
-        public IEnumerable<NameDescription> Set(SocketGuild guild, IEnumerable<NameDescription> value, TimeSpan absoluteExpirationRelativeToNow)
-        {
-            if (guild == null)
-            {
-                return default;
-            }
-
-            return this.memoryCache.Set(this.GetCacheKey(guild), value, absoluteExpirationRelativeToNow);
-        }
-
-        /// <summary>
-        /// Removes the channels associated with the given guild from the cache.
-        /// </summary>
-        /// <param name="guild">The guild whose channels to remove from the cache.</param>
-        public void Remove(SocketGuild guild)
-        {
-            if (guild == null)
-            {
-                return;
-            }
-
-            this.memoryCache.Remove(this.GetCacheKey(guild));
         }
 
         /// <summary>
@@ -98,7 +23,7 @@ namespace Reiati.ChillBot.Data
         /// </summary>
         /// <param name="guild">The guild whose key should be returned.</param>
         /// <returns>The key corresponding to the provided <paramref name="guild"/> in the cache.</returns>
-        protected string GetCacheKey(SocketGuild guild)
+        protected override string GetCacheKey(SocketGuild guild)
         {
             if (guild == null)
             {

--- a/Data/SlashCommand.cs
+++ b/Data/SlashCommand.cs
@@ -1,0 +1,53 @@
+﻿using Discord;
+using Discord.Interactions;
+using Reiati.ChillBot.Tools;
+
+namespace Reiati.ChillBot.Data
+{
+    /// <summary>
+    /// An object representing a slash command.
+    /// </summary>
+    public class SlashCommand : IEntity<ulong>
+    {
+        /// <summary>
+        /// The ID used for the slash command when the actual ID cannot be determined.
+        /// </summary>
+        public const ulong UnknownId = ulong.MinValue;
+
+        /// <summary>
+        /// Gets the unique ID of the slash command.
+        /// </summary>
+        public ulong Id { get; }
+
+        /// <summary>
+        /// Gets the representation of metadata information about the slash command.
+        /// </summary>
+        public SlashCommandInfo SlashCommandInfo { get; }
+
+        /// <summary>
+        /// Gets the text that can be used to link to the slash command within a Discord message.
+        /// </summary>
+        public string CommandLinkText => this.Id != SlashCommand.UnknownId ? $"</{this.SlashCommandInfo.Name}:{this.Id}>" : $"/{this.SlashCommandInfo.Name}";
+
+        /// <summary>
+        /// Constructs a new <see cref="SlashCommand"/>.
+        /// </summary>
+        /// <param name="id">The unique ID of the slash command.</param>
+        /// <param name="slashCommandInfo">The metadata information for the slash command.</param>
+        public SlashCommand(ulong id, SlashCommandInfo slashCommandInfo)
+        {
+            this.Id = id;
+
+            ValidateArg.IsNotNull(slashCommandInfo, nameof(slashCommandInfo));
+            this.SlashCommandInfo = slashCommandInfo;
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="SlashCommand"/> with an unknown ID (<see cref="SlashCommand.UnknownId"/>).
+        /// </summary>
+        /// <param name="slashCommandInfo">The metadata information for the slash command.</param>
+        public SlashCommand(SlashCommandInfo slashCommandInfo) : this(SlashCommand.UnknownId, slashCommandInfo)
+        {
+        }
+    }
+}

--- a/Data/SlashCommandCacheManager.cs
+++ b/Data/SlashCommandCacheManager.cs
@@ -1,0 +1,140 @@
+﻿using Discord;
+using Discord.Interactions;
+using Discord.Rest;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+using Reiati.ChillBot.Tools;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Reiati.ChillBot.Data
+{
+    /// <summary>
+    /// An object that manages a cache of slash commands by guild.
+    /// </summary>
+    public class SlashCommandCacheManager : ISlashCommandCacheManager
+    {
+        /// <summary>
+        /// A logger.
+        /// </summary>
+        private ILogger logger;
+
+        /// <summary>
+        /// The client used to connect to Discord.
+        /// </summary>
+        private DiscordShardedClient client;
+
+        /// <summary>
+        /// The service for registering and reading Discord commands.
+        /// </summary>
+        private InteractionService interactionService;
+
+        /// <summary>
+        /// Cache of slash commands.
+        /// </summary>
+        private ISlashCommandCache slashCommandCache;
+
+        /// <summary>
+        /// /// Constructs a new <see cref="SlashCommandCacheManager"/>.
+        /// </summary>
+        /// <param name="logger">A logger.</param>
+        /// <param name="client">The client used to connect to Discord.</param>
+        /// <param name="interactionService">The service for registering and reading Discord commands.</param>
+        /// <param name="slashCommandCache">Cache of slash commands.</param>
+        public SlashCommandCacheManager(ILogger<SlashCommandCacheManager> logger, DiscordShardedClient client, InteractionService interactionService, ISlashCommandCache slashCommandCache)
+        {
+            ValidateArg.IsNotNull(logger, nameof(logger));
+            this.logger = logger;
+
+            ValidateArg.IsNotNull(client, nameof(client));
+            this.client = client;
+
+            ValidateArg.IsNotNull(interactionService, nameof(interactionService));
+            this.interactionService = interactionService;
+
+            ValidateArg.IsNotNull(slashCommandCache, nameof(slashCommandCache));
+            this.slashCommandCache = slashCommandCache;
+        }
+
+        /// <summary>
+        /// Retrieves a dictionary of slash commands from the cache if present or queries the slash commands from Discord if they are not already cached.
+        /// </summary>
+        /// <param name="guild">The connection to the guild for querying slash commands.</param>
+        /// <returns>The slash command information for the guild.</returns>
+        public async Task<IReadOnlyCollection<SlashCommand>> GetAllSlashCommandsAsync(SocketGuild guild)
+        {
+            IReadOnlyDictionary<SlashCommandInfo, SlashCommand> commands = await this.GetSlashCommandDictionary(guild).ConfigureAwait(false);
+            return new ReadOnlyCollection<SlashCommand>(commands.Values.ToList());
+        }
+
+        /// <summary>
+        /// Retrieves information about a specific slash command from the cache if present or queries the slash command from Discord if it is not already cached.
+        /// </summary>
+        /// <typeparam name="TModule">Declaring module type of this slash command, must be a type of <see cref="Discord.Interactions.InteractionModuleBase"/>.</typeparam>
+        /// <param name="guild">The connection to the guild for querying slash commands.</param>
+        /// <param name="methodName">Method name of the slash command handler, use of <see cref="nameof"/> is recommended.</param>
+        /// <returns>The slash command information for the guild.</returns>
+        public async Task<SlashCommand> GetSlashCommandInfoAsync<TModule>(SocketGuild guild, string methodName) where TModule : class
+        {
+            try
+            {
+                SlashCommandInfo slashCommandInfo = this.interactionService.GetSlashCommandInfo<TModule>(methodName);
+
+                IReadOnlyDictionary<SlashCommandInfo, SlashCommand> commands = await this.GetSlashCommandDictionary(guild).ConfigureAwait(false);
+                if (!commands.TryGetValue(slashCommandInfo, out SlashCommand slashCommand))
+                {
+                    this.logger.LogWarning("Slash command not found for module {moduleType} and method {methodName} in guild {guildId}. Is it registered?", typeof(TModule).FullName, methodName, guild.Id);
+                    
+                    // Still return the slash command information despite it not being enriched with the guild-specific information
+                    return new SlashCommand(slashCommandInfo);
+                }
+
+                return slashCommand;
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError(ex, "Error while getting slash command for module {moduleType} and method {methodName} in guild {guildId}.", typeof(TModule).FullName, methodName, guild.Id);
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Gets the slash command dictionary from the cache or, if it is not present in the cache, constructs the slash command dictionary and stores it in the cache for future use.
+        /// </summary>
+        /// <param name="guild">The connection to the guild for querying slash commands.</param>
+        /// <returns>The dictionary of slash command information for the guild.</returns>
+        protected async Task<IReadOnlyDictionary<SlashCommandInfo, SlashCommand>> GetSlashCommandDictionary(SocketGuild guild)
+        {
+            try
+            {
+                if (!this.slashCommandCache.TryGetValue(guild, out IReadOnlyDictionary<SlashCommandInfo, SlashCommand> slashCommands))
+                {
+                    // Read all of the application commands from Discord
+                    IReadOnlyCollection<RestGlobalCommand> restGlobalCommands = await this.client.Rest.GetGlobalApplicationCommands().ConfigureAwait(false);
+                    IReadOnlyCollection<RestGuildCommand> restGuildCommands = await this.client.Rest.GetGuildApplicationCommands(guild.Id).ConfigureAwait(false);
+                    List<RestApplicationCommand> allRestSlashCommands = restGlobalCommands.Cast<RestApplicationCommand>().Concat(restGuildCommands).Where(c => c.Type == ApplicationCommandType.Slash).ToList();
+
+                    // Construct the dictionary of slash commands
+                    var slashCommandDictionary = this.interactionService.SlashCommands.ToDictionary(
+                        slashCommandInfo => slashCommandInfo,
+                        slashCommandInfo => new SlashCommand(allRestSlashCommands.FirstOrDefault(restCommand => string.Equals(restCommand.Name, slashCommandInfo.Name, StringComparison.OrdinalIgnoreCase))?.Id ?? SlashCommand.UnknownId, slashCommandInfo));
+
+                    slashCommands = new ReadOnlyDictionary<SlashCommandInfo, SlashCommand>(slashCommandDictionary);
+
+                    // Store the dictionary of slash commands in the cache
+                    this.slashCommandCache.Set(guild, slashCommands);
+                }
+
+                return slashCommands;
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError(ex, "Error reading or populating the slash command dictionary.");
+                return this.interactionService.SlashCommands.ToDictionary(slashCommandInfo => slashCommandInfo, slashCommandInfo => new SlashCommand(slashCommandInfo));
+            }
+        }
+    }
+}

--- a/Data/SlashCommandMemoryCache.cs
+++ b/Data/SlashCommandMemoryCache.cs
@@ -1,0 +1,36 @@
+﻿using Discord.Interactions;
+using Discord.WebSocket;
+using Microsoft.Extensions.Caching.Memory;
+using System.Collections.Generic;
+
+namespace Reiati.ChillBot.Data
+{
+    /// <summary>
+    /// An object that manages a cache of slash command information by guild.
+    /// </summary>
+    public class SlashCommandMemoryCache : GuildMemoryCache<IReadOnlyDictionary<SlashCommandInfo, SlashCommand>>, ISlashCommandCache
+    {
+        /// <summary>
+        /// Constructs a <see cref="SlashCommandMemoryCache"/>
+        /// </summary>
+        /// <param name="memoryCache">The memory cache to use for caching slash commands.</param>
+        public SlashCommandMemoryCache(IMemoryCache memoryCache) : base(memoryCache)
+        {
+        }
+
+        /// <summary>
+        /// Gets the key used to store the provided guild in the cache.
+        /// </summary>
+        /// <param name="guild">The guild whose key should be returned.</param>
+        /// <returns>The key corresponding to the provided <paramref name="guild"/> in the cache.</returns>
+        protected override string GetCacheKey(SocketGuild guild)
+        {
+            if (guild == null)
+            {
+                return default;
+            }
+
+            return nameof(SlashCommandMemoryCache) + "_" + guild.Id.ToString();
+        }
+    }
+}

--- a/Engines/CommandEngine.cs
+++ b/Engines/CommandEngine.cs
@@ -64,16 +64,24 @@ namespace Reiati.ChillBot.Engines
         private IGuildRepository guildRepository;
 
         /// <summary>
+        /// Cache for slash command details.
+        /// </summary>
+        private ISlashCommandCacheManager slashCommandCache;
+
+        /// <summary>
         /// Constructs a new <see cref="CommandEngine"/>.
         /// </summary>
         /// <param name="discordClient">A client to interact with discord. May not be null.</param>
         /// <param name="guildRepository">The repository used to read and write <see cref="Guild"/>s.</param>
-        public CommandEngine(BaseSocketClient discordClient, IGuildRepository guildRepository)
+        /// <param name="slashCommandCache">Cache for slash command details.</param>
+        public CommandEngine(BaseSocketClient discordClient, IGuildRepository guildRepository, ISlashCommandCacheManager slashCommandCache)
         {
             ValidateArg.IsNotNull(discordClient, nameof(discordClient));
             ValidateArg.IsNotNull(guildRepository, nameof(guildRepository));
+            ValidateArg.IsNotNull(slashCommandCache, nameof(slashCommandCache));
             this.discordClient = discordClient;
             this.guildRepository = guildRepository;
+            this.slashCommandCache = slashCommandCache;
             this.botId = new Lazy<Snowflake>(this.GetBotId);
 
             this.dmHandlers = new List<IMessageHandler>()
@@ -86,7 +94,7 @@ namespace Reiati.ChillBot.Engines
                 new HelpGuildHandler(),
                 new JoinOptinGuildHandler(this.guildRepository),
                 new ListOptinsGuildHandler(this.guildRepository),
-                new NewOptinGuildHandler(this.guildRepository),
+                new NewOptinGuildHandler(this.guildRepository, this.slashCommandCache),
                 new RenameOptinGuildHandler(this.guildRepository),
                 new RedescribeOptinGuildHandler(this.guildRepository),
             };

--- a/Program.cs
+++ b/Program.cs
@@ -1,7 +1,6 @@
 using Discord;
 using Discord.Interactions;
 using Discord.WebSocket;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/Program.cs
+++ b/Program.cs
@@ -143,6 +143,10 @@ namespace Reiati.ChillBot
                     services.AddSingleton<IOptinChannelCache, OptinChannelMemoryCache>();
                     services.AddSingleton<IOptinChannelCacheManager, OptinChannelCacheManager>();
 
+                    // Add services for caching slash commands
+                    services.AddSingleton<ISlashCommandCache, SlashCommandMemoryCache>();
+                    services.AddSingleton<ISlashCommandCacheManager, SlashCommandCacheManager>();
+
                     // Add the main service for Chill Bot
                     services.AddHostedService<ChillBotService>();
                 })


### PR DESCRIPTION
This change leverages the `</NAME:COMMAND_ID>` message formatting described at https://discord.com/developers/docs/reference#message-formatting to link to the `/join` slash command when it is referenced in a message from the bot to the user.

To supports this functionality, a cache of slash commands per guild (`SlashCommandMemoryCache`) has been added so that the `COMMAND_ID` can be quickly retrieved for any slash command the bot implements.

The `OptinChannelMemoryCache` has also been refactored into a more generic `GuildMemoryCache<TItem>` so that code can be shared with the new `SlashCommandMemoryCache`.