### PR TITLE
Link to optin channel in successful operation response messages

### DIFF
--- a/Behavior/OptinChannel.cs
+++ b/Behavior/OptinChannel.cs
@@ -6,6 +6,7 @@ using Discord;
 using Discord.WebSocket;
 using Reiati.ChillBot.Data;
 using Reiati.ChillBot.Tools;
+using static Reiati.ChillBot.Behavior.OptinChannel;
 
 namespace Reiati.ChillBot.Behavior
 {
@@ -35,7 +36,7 @@ namespace Reiati.ChillBot.Behavior
         /// <param name="checkPermission">Whether to check if the user has permission to perform this action.</param>
         /// <param name="joinCommandLink">An optional link to the join command that can be used to join the new channel.</param>
         /// <returns>The result of the request.</returns>
-        public static async Task<CreateResult> Create(
+        public static async Task<OptinChannelOperationResult<CreateResult>> Create(
             SocketGuild guildConnection,
             Guild guildData,
             SocketGuildUser requestAuthor,
@@ -48,7 +49,7 @@ namespace Reiati.ChillBot.Behavior
 
             if (!guildData.OptinParentCategory.HasValue)
             {
-                return CreateResult.NoOptinCategory;
+                return CreateResult.NoOptinCategory.ToOptinChannelOperationResult();
             }
             var optinsCategory = guildData.OptinParentCategory.GetValueOrDefault();
 
@@ -61,7 +62,7 @@ namespace Reiati.ChillBot.Behavior
                     allowedRoles: guildData.OptinCreatorsRoles);
                 if (!hasPermission)
                 {
-                    return CreateResult.NoPermissions;
+                    return CreateResult.NoPermissions.ToOptinChannelOperationResult();
                 }
             }
 
@@ -71,7 +72,7 @@ namespace Reiati.ChillBot.Behavior
                 .Any(x => string.Compare(x, channelName, ignoreCase: true) == 0);
             if (alreadyExists)
             {
-                return CreateResult.ChannelNameUsed;
+                return CreateResult.ChannelNameUsed.ToOptinChannelOperationResult();
             }
 
             var createdTextChannel = await guildConnection.CreateTextChannelAsync(channelName, settings =>
@@ -103,7 +104,7 @@ namespace Reiati.ChillBot.Behavior
                 joinCommandLink: joinCommandLink)
                 .ConfigureAwait(false);
 
-            return CreateResult.Success;
+            return CreateResult.Success.ToOptinChannelOperationResult(createdTextChannel.Id);
         }
 
         /// <summary>
@@ -118,7 +119,7 @@ namespace Reiati.ChillBot.Behavior
         /// <param name="newChannelName">The requested new name of the channel. May not be null.</param>
         /// <param name="checkPermission">Whether to check if the user has permission to perform this action.</param>
         /// <returns>The result of the request.</returns>
-        public static async Task<RenameResult> Rename(
+        public static async Task<OptinChannelOperationResult<RenameResult>> Rename(
             SocketGuild guildConnection,
             Guild guildData,
             SocketGuildUser requestAuthor,
@@ -131,7 +132,7 @@ namespace Reiati.ChillBot.Behavior
 
             if (!guildData.OptinParentCategory.HasValue)
             {
-                return RenameResult.NoOptinCategory;
+                return RenameResult.NoOptinCategory.ToOptinChannelOperationResult();
             }
             var optinsCategory = guildData.OptinParentCategory.GetValueOrDefault();
 
@@ -143,7 +144,7 @@ namespace Reiati.ChillBot.Behavior
                     allowedRoles: guildData.OptinUpdatersRoles);
                 if (!hasPermission)
                 {
-                    return RenameResult.NoPermissions;
+                    return RenameResult.NoPermissions.ToOptinChannelOperationResult();
                 }
             }
 
@@ -156,7 +157,7 @@ namespace Reiati.ChillBot.Behavior
                 .SingleOrDefault();
             if (currentChannel == default)
             {
-                return RenameResult.NoSuchChannel;
+                return RenameResult.NoSuchChannel.ToOptinChannelOperationResult();
             }
 
             // Verify the new channel name is not already in use
@@ -165,7 +166,7 @@ namespace Reiati.ChillBot.Behavior
                 .Any(x => string.Compare(x, newChannelName, ignoreCase: true) == 0);
             if (newChannelAlreadyExists)
             {
-                return RenameResult.NewChannelNameUsed;
+                return RenameResult.NewChannelNameUsed.ToOptinChannelOperationResult();
             }
 
             // Modify the channel name
@@ -182,7 +183,7 @@ namespace Reiati.ChillBot.Behavior
                 newChannelName: newChannelName)
                 .ConfigureAwait(false);
 
-            return RenameResult.Success;
+            return RenameResult.Success.ToOptinChannelOperationResult(currentChannel.Id);
         }
 
         /// <summary>
@@ -197,7 +198,7 @@ namespace Reiati.ChillBot.Behavior
         /// <param name="description">The requested description of the channel.</param>
         /// <param name="checkPermission">Whether to check if the user has permission to perform this action.</param>
         /// <returns>The result of the request.</returns>
-        public static async Task<UpdateDescriptionResult> UpdateDescription(
+        public static async Task<OptinChannelOperationResult<UpdateDescriptionResult>> UpdateDescription(
             SocketGuild guildConnection,
             Guild guildData,
             SocketGuildUser requestAuthor,
@@ -209,7 +210,7 @@ namespace Reiati.ChillBot.Behavior
 
             if (!guildData.OptinParentCategory.HasValue)
             {
-                return UpdateDescriptionResult.NoOptinCategory;
+                return UpdateDescriptionResult.NoOptinCategory.ToOptinChannelOperationResult();
             }
             var optinsCategory = guildData.OptinParentCategory.GetValueOrDefault();
 
@@ -221,7 +222,7 @@ namespace Reiati.ChillBot.Behavior
                     allowedRoles: guildData.OptinUpdatersRoles);
                 if (!hasPermission)
                 {
-                    return UpdateDescriptionResult.NoPermissions;
+                    return UpdateDescriptionResult.NoPermissions.ToOptinChannelOperationResult();
                 }
             }
 
@@ -234,7 +235,7 @@ namespace Reiati.ChillBot.Behavior
                 .SingleOrDefault();
             if (currentChannel == default)
             {
-                return UpdateDescriptionResult.NoSuchChannel;
+                return UpdateDescriptionResult.NoSuchChannel.ToOptinChannelOperationResult();
             }
 
             // Modify the channel description
@@ -256,7 +257,7 @@ namespace Reiati.ChillBot.Behavior
                     .ConfigureAwait(false);
             }
 
-            return UpdateDescriptionResult.Success;
+            return UpdateDescriptionResult.Success.ToOptinChannelOperationResult(currentChannel.Id);
         }
 
         /// <summary>
@@ -269,7 +270,7 @@ namespace Reiati.ChillBot.Behavior
         /// <param name="requestAuthor">The author of the join channel request. May not be null.</param>
         /// <param name="channelName">The name of the channel to join.</param>
         /// <returns>The result of the request.</returns>
-        public static async Task<JoinResult> Join(
+        public static async Task<OptinChannelOperationResult<JoinResult>> Join(
             SocketGuild guildConnection,
             Guild guildData,
             SocketGuildUser requestAuthor,
@@ -277,7 +278,7 @@ namespace Reiati.ChillBot.Behavior
         {
             if (!guildData.OptinParentCategory.HasValue)
             {
-                return JoinResult.NoOptinCategory;
+                return JoinResult.NoOptinCategory.ToOptinChannelOperationResult();
             }
             var optinsCategory = guildData.OptinParentCategory.GetValueOrDefault();
 
@@ -287,7 +288,7 @@ namespace Reiati.ChillBot.Behavior
 
             if (requestedChannel == null)
             {
-                return JoinResult.NoSuchChannel;
+                return JoinResult.NoSuchChannel.ToOptinChannelOperationResult();
             }
             
             var associatedRoleName = OptinChannel.GetRoleName(requestedChannel.Id);
@@ -296,11 +297,11 @@ namespace Reiati.ChillBot.Behavior
 
             if (role == null)
             {
-                return JoinResult.RoleMissing;
+                return JoinResult.RoleMissing.ToOptinChannelOperationResult(requestedChannel.Id);
             }
 
             await requestAuthor.AddRoleAsync(role).ConfigureAwait(false);
-            return JoinResult.Success;
+            return JoinResult.Success.ToOptinChannelOperationResult(requestedChannel.Id);
         }
 
 
@@ -314,7 +315,7 @@ namespace Reiati.ChillBot.Behavior
         /// <param name="requestAuthor">The author of the join channel request. May not be null.</param>
         /// <param name="channelName">The name of the channel to join.</param>
         /// <returns>The result of the request.</returns>
-        public static async Task<LeaveResult> Leave(
+        public static async Task<OptinChannelOperationResult<LeaveResult>> Leave(
             SocketGuild guildConnection,
             Guild guildData,
             SocketGuildUser requestAuthor,
@@ -322,7 +323,7 @@ namespace Reiati.ChillBot.Behavior
         {
             if (!guildData.OptinParentCategory.HasValue)
             {
-                return LeaveResult.NoOptinCategory;
+                return LeaveResult.NoOptinCategory.ToOptinChannelOperationResult();
             }
             var optinsCategory = guildData.OptinParentCategory.GetValueOrDefault();
 
@@ -332,7 +333,7 @@ namespace Reiati.ChillBot.Behavior
 
             if (requestedChannel == null)
             {
-                return LeaveResult.NoSuchChannel;
+                return LeaveResult.NoSuchChannel.ToOptinChannelOperationResult();
             }
             
             var associatedRoleName = OptinChannel.GetRoleName(requestedChannel.Id);
@@ -341,11 +342,11 @@ namespace Reiati.ChillBot.Behavior
 
             if (role == null)
             {
-                return LeaveResult.RoleMissing;
+                return LeaveResult.RoleMissing.ToOptinChannelOperationResult(requestedChannel.Id);
             }
 
             await requestAuthor.RemoveRoleAsync(role).ConfigureAwait(false);
-            return LeaveResult.Success;
+            return LeaveResult.Success.ToOptinChannelOperationResult(requestedChannel.Id);
         }
 
         /// <summary>
@@ -384,7 +385,44 @@ namespace Reiati.ChillBot.Behavior
         {
             return "chill-" + optinChannel.Value;
         }
-        
+
+        /// <summary>
+        /// Result type of an operation performed on an <see cref="OptinChannel"/>.
+        /// </summary>
+        public readonly struct OptinChannelOperationResult<TResult> where TResult : struct, Enum
+        {
+            /// <summary>Result code representing more details about the success or failure of the optin channel operation</summary>
+            public TResult ResultCode { get; init; }
+
+            /// <summary>If the operation was successful, the channel ID associated with the optin channel operation</summary>
+            public ulong ChannelId { get; init; }
+
+            /// <summary>
+            /// Constructs a <see cref="OptinChannelOperationResult{TResult}"/>.
+            /// </summary>
+            /// <param name="resultCode">Result code representing more details about the success or failure of the optin channel operation</param>
+            /// <param name="channelId">If the operation was successful, the channel ID associated with the optin channel operation</param>
+            public OptinChannelOperationResult(TResult resultCode, ulong channelId)
+            {
+                this.ResultCode = resultCode;
+                this.ChannelId = channelId;
+            }
+
+            /// <summary>
+            /// Constructs a <see cref="OptinChannelOperationResult{TResult}"/>.
+            /// </summary>
+            /// <param name="resultCode">Result code representing more details about the success or failure of the optin channel operation</param>
+            public OptinChannelOperationResult(TResult resultCode)
+                : this(resultCode, default)
+            {
+            }
+
+            public override string ToString()
+            {
+                return this.ResultCode.ToString();
+            }
+        }
+
         /// <summary>
         /// Result type of a <see cref="OptinChannel.Create(SocketGuild, Guild, SocketGuildUser, string, string)"/>
         /// call.
@@ -571,6 +609,35 @@ namespace Reiati.ChillBot.Behavior
                     this.description = description;
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Extension methods to help work with <see cref="OptinChannelOperationResult{TResult}"/>.
+    /// </summary>
+    internal static class OptinChannelOperationResultExtensions
+    {
+        /// <summary>
+        /// Convert an operation result code into a <see cref="OptinChannelOperationResult{TResult}"/>.
+        /// </summary>
+        /// <typeparam name="TResult">The type representing the possible result codes of the operation.</typeparam>
+        /// <param name="resultCode">Result code representing more details about the success or failure of the optin channel operation</param>
+        /// <param name="channelId">The channel ID associated with the optin channel operation</param>
+        /// <returns>A new <see cref="OptinChannelOperationResult{TResult}"/></returns>
+        public static OptinChannelOperationResult<TResult> ToOptinChannelOperationResult<TResult>(this TResult resultCode, ulong channelId) where TResult : struct, Enum
+        {
+            return new OptinChannelOperationResult<TResult>(resultCode, channelId);
+        }
+
+        /// <summary>
+        /// Convert an operation result code into a <see cref="OptinChannelOperationResult{TResult}"/>.
+        /// </summary>
+        /// <typeparam name="TResult">The type representing the possible result codes of the operation.</typeparam>
+        /// <param name="resultCode">Result code representing more details about the success or failure of the optin channel operation</param>
+        /// <returns>A new <see cref="OptinChannelOperationResult{TResult}"/></returns>
+        public static OptinChannelOperationResult<TResult> ToOptinChannelOperationResult<TResult>(this TResult resultCode) where TResult : struct, Enum
+        {
+            return new OptinChannelOperationResult<TResult>(resultCode);
         }
     }
 }

--- a/Commands/CreateOptinCommand.cs
+++ b/Commands/CreateOptinCommand.cs
@@ -91,15 +91,15 @@ namespace Reiati.ChillBot.Commands
                                 checkPermission: false,  // Slash commands can have permissions configured by the server admin, so do not perform our own permission check
                                 joinCommandLink: joinSlashCommand?.CommandLinkText)
                                 .ConfigureAwait(false);
-                            borrowedGuild.Commit = createResult == OptinChannel.CreateResult.Success;
+                            borrowedGuild.Commit = createResult.ResultCode == OptinChannel.CreateResult.Success;
 
-                            switch (createResult)
+                            switch (createResult.ResultCode)
                             {
                                 case OptinChannel.CreateResult.Success:
                                     // Clear the opt-in channel cache for this guild since a new opt-in channel was created
                                     this.optinChannelCache.ClearCache(this.Context.Guild);
 
-                                    await this.RespondAsync($"{CreateOptinCommand.SuccessEmoji} New channel created. Enjoy!")
+                                    await this.RespondAsync($"{CreateOptinCommand.SuccessEmoji} New channel <#{createResult.ChannelId}> created. Enjoy!")
                                         .ConfigureAwait(false);
                                     break;
 
@@ -121,7 +121,7 @@ namespace Reiati.ChillBot.Commands
                                     break;
 
                                 default:
-                                    throw new NotImplementedException(createResult.ToString());
+                                    throw new NotImplementedException(createResult.ResultCode.ToString());
                             }
                         }
                         break;

--- a/Commands/JoinOptinCommand.cs
+++ b/Commands/JoinOptinCommand.cs
@@ -61,12 +61,12 @@ namespace Reiati.ChillBot.Commands
                                 guildData: guildData,
                                 requestAuthor: this.Context.User as SocketGuildUser,
                                 channelName: channelName);
-                            borrowedGuild.Commit = joinResult == OptinChannel.JoinResult.Success;
+                            borrowedGuild.Commit = joinResult.ResultCode == OptinChannel.JoinResult.Success;
 
-                            switch (joinResult)
+                            switch (joinResult.ResultCode)
                             {
                                 case OptinChannel.JoinResult.Success:
-                                    await this.RespondAsync($"{JoinOptinCommand.SuccessEmoji} Welcome to {channelName}!")
+                                    await this.RespondAsync($"{JoinOptinCommand.SuccessEmoji} Welcome to <#{joinResult.ChannelId}>!")
                                         .ConfigureAwait(false);
                                     break;
 
@@ -89,7 +89,7 @@ namespace Reiati.ChillBot.Commands
                                     break;
 
                                 default:
-                                    throw new NotImplementedException(joinResult.ToString());
+                                    throw new NotImplementedException(joinResult.ResultCode.ToString());
                             }
                         }
                         break;

--- a/Commands/LeaveOptinCommand.cs
+++ b/Commands/LeaveOptinCommand.cs
@@ -70,7 +70,7 @@ namespace Reiati.ChillBot.Commands
                                 channelName: channelName)
                                 .ConfigureAwait(false);
 
-                            switch (leaveResult)
+                            switch (leaveResult.ResultCode)
                             {
                                 case OptinChannel.LeaveResult.Success:
                                     await this.RespondAsync($"{LeaveOptinCommand.SuccessEmoji} You have left {channelName}.")
@@ -93,7 +93,7 @@ namespace Reiati.ChillBot.Commands
                                     break;
 
                                 default:
-                                    throw new NotImplementedException(leaveResult.ToString());
+                                    throw new NotImplementedException(leaveResult.ResultCode.ToString());
                             }
                         }
                         break;

--- a/Commands/RedescribeOptinCommand.cs
+++ b/Commands/RedescribeOptinCommand.cs
@@ -71,15 +71,15 @@ namespace Reiati.ChillBot.Commands
                                 description: newChannelDescription,
                                 checkPermission: false); // Slash commands can have permissions configured by the server admin outside of the bot, so do not perform our own permission check
 
-                            borrowedGuild.Commit = updateResult == OptinChannel.UpdateDescriptionResult.Success;
+                            borrowedGuild.Commit = updateResult.ResultCode == OptinChannel.UpdateDescriptionResult.Success;
 
-                            switch (updateResult)
+                            switch (updateResult.ResultCode)
                             {
                                 case OptinChannel.UpdateDescriptionResult.Success:
                                     // Clear the opt-in channel cache for this guild since a opt-in channel was updated
                                     this.optinChannelCache.ClearCache(this.Context.Guild);
 
-                                    await this.RespondAsync($"{RedescribeOptinCommand.SuccessEmoji} Channel description updated.")
+                                    await this.RespondAsync($"{RedescribeOptinCommand.SuccessEmoji} Channel <#{updateResult.ChannelId}> description updated.")
                                         .ConfigureAwait(false);
                                     break;
 
@@ -100,7 +100,7 @@ namespace Reiati.ChillBot.Commands
                                     break;
 
                                 default:
-                                    throw new NotImplementedException(updateResult.ToString());
+                                    throw new NotImplementedException(updateResult.ResultCode.ToString());
                             }
                         }
                         break;

--- a/Commands/RenameOptinCommand.cs
+++ b/Commands/RenameOptinCommand.cs
@@ -71,15 +71,15 @@ namespace Reiati.ChillBot.Commands
                                 newChannelName: newChannelName,
                                 checkPermission: false); // Slash commands can have permissions configured by the server admin outside of the bot, so do not perform our own permission check
 
-                            borrowedGuild.Commit = renameResult == OptinChannel.RenameResult.Success;
+                            borrowedGuild.Commit = renameResult.ResultCode == OptinChannel.RenameResult.Success;
 
-                            switch (renameResult)
+                            switch (renameResult.ResultCode)
                             {
                                 case OptinChannel.RenameResult.Success:
                                     // Clear the opt-in channel cache for this guild since a opt-in channel was updated
                                     this.optinChannelCache.ClearCache(this.Context.Guild);
 
-                                    await this.RespondAsync($"{RenameOptinCommand.SuccessEmoji} Channel renamed.")
+                                    await this.RespondAsync($"{RenameOptinCommand.SuccessEmoji} Channel <#{renameResult.ChannelId}> renamed.")
                                         .ConfigureAwait(false);
                                     break;
 
@@ -106,7 +106,7 @@ namespace Reiati.ChillBot.Commands
                                     break;
 
                                 default:
-                                    throw new NotImplementedException(renameResult.ToString());
+                                    throw new NotImplementedException(renameResult.ResultCode.ToString());
                             }
                         }
                         break;

--- a/EventHandlers/JoinOptinGuildHandler.cs
+++ b/EventHandlers/JoinOptinGuildHandler.cs
@@ -92,9 +92,9 @@ namespace Reiati.ChillBot.EventHandlers
                                 guildData: guildData,
                                 requestAuthor: author,
                                 channelName: channelName);
-                            borrowedGuild.Commit = joinResult == OptinChannel.JoinResult.Success;
+                            borrowedGuild.Commit = joinResult.ResultCode == OptinChannel.JoinResult.Success;
 
-                            switch (joinResult)
+                            switch (joinResult.ResultCode)
                             {
                                 case OptinChannel.JoinResult.Success:
                                     await message.AddReactionAsync(JoinOptinGuildHandler.SuccessEmoji)
@@ -123,7 +123,7 @@ namespace Reiati.ChillBot.EventHandlers
                                 break;
 
                                 default:
-                                    throw new NotImplementedException(joinResult.ToString());
+                                    throw new NotImplementedException(joinResult.ResultCode.ToString());
                             }
                         }
                     break;

--- a/EventHandlers/LeaveOptinDmHandler.cs
+++ b/EventHandlers/LeaveOptinDmHandler.cs
@@ -112,7 +112,7 @@ namespace Reiati.ChillBot.EventHandlers
                                 channelName: channelName)
                                 .ConfigureAwait(false);
 
-                            switch (leaveResult)
+                            switch (leaveResult.ResultCode)
                             {
                                 case OptinChannel.LeaveResult.Success:
                                     await message.AddReactionAsync(LeaveOptinDmHandler.SuccessEmoji)
@@ -135,7 +135,7 @@ namespace Reiati.ChillBot.EventHandlers
                                 break;
 
                                 default:
-                                    throw new NotImplementedException(leaveResult.ToString());
+                                    throw new NotImplementedException(leaveResult.ResultCode.ToString());
                             }
                         }
                     break;

--- a/EventHandlers/NewOptinGuildHandler.cs
+++ b/EventHandlers/NewOptinGuildHandler.cs
@@ -116,9 +116,9 @@ namespace Reiati.ChillBot.EventHandlers
                                 description: description,
                                 joinCommandLink: joinSlashCommand?.CommandLinkText)
                                 .ConfigureAwait(false);
-                            borrowedGuild.Commit = createResult == OptinChannel.CreateResult.Success;
+                            borrowedGuild.Commit = createResult.ResultCode == OptinChannel.CreateResult.Success;
 
-                            switch (createResult)
+                            switch (createResult.ResultCode)
                             {
                                 case OptinChannel.CreateResult.Success:
                                     await message.AddReactionAsync(NewOptinGuildHandler.SuccessEmoji)
@@ -147,7 +147,7 @@ namespace Reiati.ChillBot.EventHandlers
                                 break;
 
                                 default:
-                                    throw new NotImplementedException(createResult.ToString());
+                                    throw new NotImplementedException(createResult.ResultCode.ToString());
                             }
                         }
                     break;

--- a/EventHandlers/RedescribeOptinGuildHandler.cs
+++ b/EventHandlers/RedescribeOptinGuildHandler.cs
@@ -103,9 +103,9 @@ namespace Reiati.ChillBot.EventHandlers
                                 requestAuthor: author,
                                 channelName: channelName,
                                 description: description);
-                            borrowedGuild.Commit = updateResult == OptinChannel.UpdateDescriptionResult.Success;
+                            borrowedGuild.Commit = updateResult.ResultCode == OptinChannel.UpdateDescriptionResult.Success;
 
-                            switch (updateResult)
+                            switch (updateResult.ResultCode)
                             {
                                 case OptinChannel.UpdateDescriptionResult.Success:
                                     await message.AddReactionAsync(RedescribeOptinGuildHandler.SuccessEmoji);
@@ -130,7 +130,7 @@ namespace Reiati.ChillBot.EventHandlers
                                     break;
 
                                 default:
-                                    throw new NotImplementedException(updateResult.ToString());
+                                    throw new NotImplementedException(updateResult.ResultCode.ToString());
                             }
                         }
                         break;

--- a/EventHandlers/RenameOptinGuildHandler.cs
+++ b/EventHandlers/RenameOptinGuildHandler.cs
@@ -101,9 +101,9 @@ namespace Reiati.ChillBot.EventHandlers
                                 requestAuthor: author,
                                 currentChannelName: currentChannelName,
                                 newChannelName: newChannelName);
-                            borrowedGuild.Commit = renameResult == OptinChannel.RenameResult.Success;
+                            borrowedGuild.Commit = renameResult.ResultCode == OptinChannel.RenameResult.Success;
 
-                            switch (renameResult)
+                            switch (renameResult.ResultCode)
                             {
                                 case OptinChannel.RenameResult.Success:
                                     await message.AddReactionAsync(RenameOptinGuildHandler.SuccessEmoji);
@@ -134,7 +134,7 @@ namespace Reiati.ChillBot.EventHandlers
                                     break;
 
                                 default:
-                                    throw new NotImplementedException(renameResult.ToString());
+                                    throw new NotImplementedException(renameResult.ResultCode.ToString());
                             }
                         }
                         break;


### PR DESCRIPTION
Link to the optin channel that was created, joined, or modified in the response messages. This will help users navigate to the optin channel after running the command.

To facilitate this, return a `OptinChannelOperationResult<TResult>` wrapper around the operation result code (`TResult`) so that the channel ID can also be returned as part of a successful result and can be used to link to the channel in the response message.