### PR TITLE
Use interfaces for Discord.Net types as much as possible

### DIFF
--- a/Behavior/IOptinChannelCacheManager.cs
+++ b/Behavior/IOptinChannelCacheManager.cs
@@ -1,4 +1,4 @@
-﻿using Discord.WebSocket;
+﻿using Discord;
 using System.Threading.Tasks;
 
 namespace Reiati.ChillBot.Behavior
@@ -14,12 +14,12 @@ namespace Reiati.ChillBot.Behavior
         /// <param name="guild">The connection to the guild for querying opt-in channels.</param>
         /// <param name="recycleResult">A preallocated result that should be returned if passed in.</param>
         /// <returns>The borrowed opt-in channel list.</returns>
-        Task<OptinChannelCacheResult> GetChannels(SocketGuild guild, OptinChannelCacheResult recycleResult);
+        Task<OptinChannelCacheResult> GetChannels(IGuild guild, OptinChannelCacheResult recycleResult);
 
         /// <summary>
         /// Removes the specified guild ID from the cache. It will need to be queried from Discord the next time it is requested.
         /// </summary>
         /// <param name="guild">The connection to the guild to remove from the cache.</param>
-        void ClearCache(SocketGuild guild);
+        void ClearCache(IGuild guild);
     }
 }

--- a/Behavior/OptinChannelAutocompleteHandler.cs
+++ b/Behavior/OptinChannelAutocompleteHandler.cs
@@ -1,6 +1,5 @@
 ﻿using Discord;
 using Discord.Interactions;
-using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
 using Reiati.ChillBot.Data;
 using Reiati.ChillBot.Tools;
@@ -50,7 +49,7 @@ namespace Reiati.ChillBot.Behavior
             {
                 string userInput = autocompleteInteraction.Data.Current.Value.ToString();
 
-                optinChannelCacheResult = await this.optinChannelCache.GetChannels(context.Guild as SocketGuild, optinChannelCacheResult);
+                optinChannelCacheResult = await this.optinChannelCache.GetChannels(context.Guild, optinChannelCacheResult);
                 switch (optinChannelCacheResult.Result)
                 {
                     case OptinChannelCacheResult.ResultType.Success:

--- a/Behavior/OptinChannelCacheManager.cs
+++ b/Behavior/OptinChannelCacheManager.cs
@@ -1,4 +1,4 @@
-﻿using Discord.WebSocket;
+﻿using Discord;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Reiati.ChillBot.Data;
@@ -82,7 +82,7 @@ namespace Reiati.ChillBot.Behavior
         /// <param name="guild">The connection to the guild for querying opt-in channels.</param>
         /// <param name="recycleResult">A preallocated result that should be returned if passed in.</param>
         /// <returns>The borrowed opt-in channel list.</returns>
-        public async Task<OptinChannelCacheResult> GetChannels(SocketGuild guild, OptinChannelCacheResult recycleResult = null)
+        public async Task<OptinChannelCacheResult> GetChannels(IGuild guild, OptinChannelCacheResult recycleResult = null)
         {
             OptinChannelCacheResult retVal = recycleResult ?? new OptinChannelCacheResult();
 
@@ -104,7 +104,7 @@ namespace Reiati.ChillBot.Behavior
                                 borrowedGuild.Commit = false;
                                 var guildData = borrowedGuild.Instance;
 
-                                listResult = OptinChannel.List(guild, guildData, listResult);
+                                listResult = await OptinChannel.List(guild, guildData, listResult).ConfigureAwait(false);
 
                                 switch (listResult.Result)
                                 {
@@ -160,7 +160,7 @@ namespace Reiati.ChillBot.Behavior
         /// Removes the specified guild ID from the cache. It will need to be queried from Discord the next time it is requested.
         /// </summary>
         /// <param name="guild">The connection to the guild to remove from the cache.</param>
-        public void ClearCache(SocketGuild guild)
+        public void ClearCache(IGuild guild)
         {
             this.optinChannelCache.Remove(guild);
         }

--- a/Behavior/OptinChannelCacheResult.cs
+++ b/Behavior/OptinChannelCacheResult.cs
@@ -4,7 +4,7 @@ using static Reiati.ChillBot.Behavior.OptinChannel.ListResult;
 namespace Reiati.ChillBot.Behavior
 {
     /// <summary>
-    /// The result of a <see cref="OptinChannelCacheManager.GetChannels(Discord.WebSocket.SocketGuild)"/> call.
+    /// The result of a <see cref="OptinChannelCacheManager.GetChannels(Discord.IGuild)"/> call.
     /// </summary>
     public sealed class OptinChannelCacheResult
     {
@@ -68,7 +68,7 @@ namespace Reiati.ChillBot.Behavior
         }
 
         /// <summary>
-        /// The result of a <see cref="OptinChannelCacheManager.GetChannels(Discord.WebSocket.SocketGuild)"/> call.
+        /// The result of a <see cref="OptinChannelCacheManager.GetChannels(Discord.IGuild)"/> call.
         /// </summary>
         public enum ResultType
         {

--- a/Commands/CreateOptinCommand.cs
+++ b/Commands/CreateOptinCommand.cs
@@ -1,6 +1,5 @@
 ﻿using Discord;
 using Discord.Interactions;
-using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
 using Reiati.ChillBot.Behavior;
 using Reiati.ChillBot.Data;
@@ -85,7 +84,7 @@ namespace Reiati.ChillBot.Commands
                             var createResult = await OptinChannel.Create(
                                 guildConnection: this.Context.Guild,
                                 guildData: guildData,
-                                requestAuthor: this.Context.User as SocketGuildUser,
+                                requestAuthor: this.Context.User as IGuildUser,
                                 channelName: channelName,
                                 description: channelDescription,
                                 checkPermission: false,  // Slash commands can have permissions configured by the server admin, so do not perform our own permission check

--- a/Commands/JoinOptinCommand.cs
+++ b/Commands/JoinOptinCommand.cs
@@ -1,5 +1,5 @@
-﻿using Discord.Interactions;
-using Discord.WebSocket;
+﻿using Discord;
+using Discord.Interactions;
 using Microsoft.Extensions.Logging;
 using Reiati.ChillBot.Behavior;
 using Reiati.ChillBot.Data;
@@ -59,7 +59,7 @@ namespace Reiati.ChillBot.Commands
                             var joinResult = await OptinChannel.Join(
                                 guildConnection: this.Context.Guild,
                                 guildData: guildData,
-                                requestAuthor: this.Context.User as SocketGuildUser,
+                                requestAuthor: this.Context.User as IGuildUser,
                                 channelName: channelName);
                             borrowedGuild.Commit = joinResult == OptinChannel.JoinResult.Success;
 

--- a/Commands/LeaveOptinCommand.cs
+++ b/Commands/LeaveOptinCommand.cs
@@ -1,6 +1,5 @@
 ﻿using Discord;
 using Discord.Interactions;
-using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
 using Reiati.ChillBot.Behavior;
 using Reiati.ChillBot.Data;
@@ -66,7 +65,7 @@ namespace Reiati.ChillBot.Commands
                             var leaveResult = await OptinChannel.Leave(
                                 guildConnection: this.Context.Guild,
                                 guildData: guildData,
-                                requestAuthor: this.Context.User as SocketGuildUser,
+                                requestAuthor: this.Context.User as IGuildUser,
                                 channelName: channelName)
                                 .ConfigureAwait(false);
 

--- a/Commands/OptinCommandBase.cs
+++ b/Commands/OptinCommandBase.cs
@@ -10,7 +10,7 @@ namespace Reiati.ChillBot.Commands
     /// <summary>
     /// Base class responsible for handling commands in a guild, related to opt-in channels.
     /// </summary>
-    public abstract class OptinCommandBase : InteractionModuleBase<ShardedInteractionContext>
+    public abstract class OptinCommandBase : InteractionModuleBase<IInteractionContext>
     {
         #region Pools
 

--- a/Commands/RedescribeOptinCommand.cs
+++ b/Commands/RedescribeOptinCommand.cs
@@ -1,6 +1,5 @@
 ﻿using Discord;
 using Discord.Interactions;
-using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
 using Reiati.ChillBot.Behavior;
 using Reiati.ChillBot.Data;
@@ -66,7 +65,7 @@ namespace Reiati.ChillBot.Commands
                             var updateResult = await OptinChannel.UpdateDescription(
                                 guildConnection: this.Context.Guild,
                                 guildData: guildData,
-                                requestAuthor: this.Context.User as SocketGuildUser,
+                                requestAuthor: this.Context.User as IGuildUser,
                                 channelName: channelName,
                                 description: newChannelDescription,
                                 checkPermission: false); // Slash commands can have permissions configured by the server admin outside of the bot, so do not perform our own permission check

--- a/Commands/RenameOptinCommand.cs
+++ b/Commands/RenameOptinCommand.cs
@@ -1,6 +1,5 @@
 ﻿using Discord;
 using Discord.Interactions;
-using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
 using Reiati.ChillBot.Behavior;
 using Reiati.ChillBot.Data;
@@ -66,7 +65,7 @@ namespace Reiati.ChillBot.Commands
                             var renameResult = await OptinChannel.Rename(
                                 guildConnection: this.Context.Guild,
                                 guildData: guildData,
-                                requestAuthor: this.Context.User as SocketGuildUser,
+                                requestAuthor: this.Context.User as IGuildUser,
                                 currentChannelName: currentChannelName,
                                 newChannelName: newChannelName,
                                 checkPermission: false); // Slash commands can have permissions configured by the server admin outside of the bot, so do not perform our own permission check

--- a/Data/GuildMemoryCache.cs
+++ b/Data/GuildMemoryCache.cs
@@ -1,4 +1,4 @@
-﻿using Discord.WebSocket;
+﻿using Discord;
 using Microsoft.Extensions.Caching.Memory;
 using Reiati.ChillBot.Tools;
 using System;
@@ -31,7 +31,7 @@ namespace Reiati.ChillBot.Data
         /// <param name="guild">The guild whose <typeparamref name="TItem"/> should be retrieved from the cache.</param>
         /// <param name="value">The <typeparamref name="TItem"/> for the provided <paramref name="guild"/>, if it was present in the cache.</param>
         /// <returns>Whether the <typeparamref name="TItem"/> for the guild was present in the cache.</returns>
-        public virtual bool TryGetValue(SocketGuild guild, out TItem value)
+        public virtual bool TryGetValue(IGuild guild, out TItem value)
         {
             if (guild == null)
             {
@@ -48,7 +48,7 @@ namespace Reiati.ChillBot.Data
         /// <param name="guild">The guild whose <typeparamref name="TItem"/> should be set in the cache.</param>
         /// <param name="value">The <typeparamref name="TItem"/> to set in the cache for this guild.</param>
         /// <returns>The value that was set.</returns>
-        public virtual TItem Set(SocketGuild guild, TItem value)
+        public virtual TItem Set(IGuild guild, TItem value)
         {
             if (guild == null)
             {
@@ -65,7 +65,7 @@ namespace Reiati.ChillBot.Data
         /// <param name="value">The <typeparamref name="TItem"/> to set in the cache for this guild.</param>
         /// <param name="absoluteExpirationRelativeToNow">The expiration time in absolute terms relative to the current time.</param>
         /// <returns>The value that was set.</returns>
-        public virtual TItem Set(SocketGuild guild, TItem value, TimeSpan absoluteExpirationRelativeToNow)
+        public virtual TItem Set(IGuild guild, TItem value, TimeSpan absoluteExpirationRelativeToNow)
         {
             if (guild == null)
             {
@@ -79,7 +79,7 @@ namespace Reiati.ChillBot.Data
         /// Removes the <typeparamref name="TItem"/> associated with the given guild from the cache.
         /// </summary>
         /// <param name="guild">The guild whose <typeparamref name="TItem"/> should be remove from the cache.</param>
-        public virtual void Remove(SocketGuild guild)
+        public virtual void Remove(IGuild guild)
         {
             if (guild == null)
             {
@@ -94,6 +94,6 @@ namespace Reiati.ChillBot.Data
         /// </summary>
         /// <param name="guild">The guild whose key should be returned.</param>
         /// <returns>The key corresponding to the provided <paramref name="guild"/> in the cache.</returns>
-        protected abstract string GetCacheKey(SocketGuild guild);
+        protected abstract string GetCacheKey(IGuild guild);
     }
 }

--- a/Data/IGuildCache.cs
+++ b/Data/IGuildCache.cs
@@ -1,4 +1,4 @@
-﻿using Discord.WebSocket;
+﻿using Discord;
 using System;
 
 namespace Reiati.ChillBot.Data
@@ -14,7 +14,7 @@ namespace Reiati.ChillBot.Data
         /// <param name="guild">The guild whose <typeparamref name="TItem"/> should be retrieved from the cache.</param>
         /// <param name="value">The <typeparamref name="TItem"/> for the provided <paramref name="guild"/>, if it was present in the cache.</param>
         /// <returns>Whether the <typeparamref name="TItem"/> for the guild were present in the cache.</returns>
-        bool TryGetValue(SocketGuild guild, out TItem value);
+        bool TryGetValue(IGuild guild, out TItem value);
 
         /// <summary>
         /// Creates or overwrites the specified entry in the cache.
@@ -22,7 +22,7 @@ namespace Reiati.ChillBot.Data
         /// <param name="guild">The guild whose <typeparamref name="TItem"/> should be set in the cache.</param>
         /// <param name="value">The <typeparamref name="TItem"/> to set in the cache for this guild.</param>
         /// <returns>The value that was set.</returns>
-        TItem Set(SocketGuild guild, TItem value);
+        TItem Set(IGuild guild, TItem value);
 
         /// <summary>
         /// Creates or overwrites the specified entry in the cache and sets the value with an absolute expiration date.
@@ -31,12 +31,12 @@ namespace Reiati.ChillBot.Data
         /// <param name="value">The <typeparamref name="TItem"/> to set in the cache for this guild.</param>
         /// <param name="absoluteExpirationRelativeToNow">The expiration time in absolute terms relative to the current time.</param>
         /// <returns>The value that was set.</returns>
-        TItem Set(SocketGuild guild, TItem value, TimeSpan absoluteExpirationRelativeToNow);
+        TItem Set(IGuild guild, TItem value, TimeSpan absoluteExpirationRelativeToNow);
 
         /// <summary>
         /// Removes the <typeparamref name="TItem"/> associated with the given guild from the cache.
         /// </summary>
         /// <param name="guild">The guild whose channels to remove from the cache.</param>
-        void Remove(SocketGuild guild);
+        void Remove(IGuild guild);
     }
 }

--- a/Data/ISlashCommandCacheManager.cs
+++ b/Data/ISlashCommandCacheManager.cs
@@ -1,4 +1,4 @@
-﻿using Discord.WebSocket;
+﻿using Discord;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -14,7 +14,7 @@ namespace Reiati.ChillBot.Data
         /// </summary>
         /// <param name="guild">The connection to the guild for querying slash commands.</param>
         /// <returns>The slash command information for the guild.</returns>
-        Task<IReadOnlyCollection<SlashCommand>> GetAllSlashCommandsAsync(SocketGuild guild);
+        Task<IReadOnlyCollection<SlashCommand>> GetAllSlashCommandsAsync(IGuild guild);
 
         /// <summary>
         /// Retrieves information about a specific slash command from the cache if present or queries the slash command from Discord if it is not already cached.
@@ -23,6 +23,6 @@ namespace Reiati.ChillBot.Data
         /// <param name="guild">The connection to the guild for querying slash commands.</param>
         /// <param name="methodName">Method name of the slash command handler, use of <see cref="nameof"/> is recommended.</param>
         /// <returns>The slash command information for the guild.</returns>
-        Task<SlashCommand> GetSlashCommandInfoAsync<TModule>(SocketGuild guild, string methodName) where TModule : class;
+        Task<SlashCommand> GetSlashCommandInfoAsync<TModule>(IGuild guild, string methodName) where TModule : class;
     }
 }

--- a/Data/OptinChannelMemoryCache.cs
+++ b/Data/OptinChannelMemoryCache.cs
@@ -1,4 +1,4 @@
-﻿using Discord.WebSocket;
+﻿using Discord;
 using Microsoft.Extensions.Caching.Memory;
 using System.Collections.Generic;
 using static Reiati.ChillBot.Behavior.OptinChannel.ListResult;
@@ -23,7 +23,7 @@ namespace Reiati.ChillBot.Data
         /// </summary>
         /// <param name="guild">The guild whose key should be returned.</param>
         /// <returns>The key corresponding to the provided <paramref name="guild"/> in the cache.</returns>
-        protected override string GetCacheKey(SocketGuild guild)
+        protected override string GetCacheKey(IGuild guild)
         {
             if (guild == null)
             {

--- a/Data/SlashCommandMemoryCache.cs
+++ b/Data/SlashCommandMemoryCache.cs
@@ -1,5 +1,5 @@
-﻿using Discord.Interactions;
-using Discord.WebSocket;
+﻿using Discord;
+using Discord.Interactions;
 using Microsoft.Extensions.Caching.Memory;
 using System.Collections.Generic;
 
@@ -23,7 +23,7 @@ namespace Reiati.ChillBot.Data
         /// </summary>
         /// <param name="guild">The guild whose key should be returned.</param>
         /// <returns>The key corresponding to the provided <paramref name="guild"/> in the cache.</returns>
-        protected override string GetCacheKey(SocketGuild guild)
+        protected override string GetCacheKey(IGuild guild)
         {
             if (guild == null)
             {

--- a/EventHandlers/AbstractRegexHandler.cs
+++ b/EventHandlers/AbstractRegexHandler.cs
@@ -1,8 +1,7 @@
-using System;
 using System.Threading.Tasks;
 using System.Text.RegularExpressions;
-using Discord.WebSocket;
 using Reiati.ChillBot.Tools;
+using Discord;
 
 namespace Reiati.ChillBot.EventHandlers
 {
@@ -30,7 +29,7 @@ namespace Reiati.ChillBot.EventHandlers
 
         /// <inheritdoc/>
         async Task<CanHandleResult> IMessageHandler.CanHandleMessage(
-            SocketMessage message,
+            IMessage message,
             CanHandleResult recycleResult)
         {
             var result = recycleResult ?? new CanHandleResult();
@@ -58,7 +57,7 @@ namespace Reiati.ChillBot.EventHandlers
         #pragma warning restore 1998 // This async method lacks 'await' operators and will run synchronously.
 
         /// <inheritdoc/>
-        Task IMessageHandler.HandleMessage(SocketMessage message, object handleCache)
+        Task IMessageHandler.HandleMessage(IMessage message, object handleCache)
         {
             return HandleMatchedMessage(message, (Match)handleCache);
         }
@@ -69,6 +68,6 @@ namespace Reiati.ChillBot.EventHandlers
         /// <param name="message">The message received.</param>
         /// <param name="handleCache">The match object returned from the regex match.</param>
         /// <returns>The handle task.</returns>
-        abstract protected Task HandleMatchedMessage(SocketMessage message, Match handleCache);
+        abstract protected Task HandleMatchedMessage(IMessage message, Match handleCache);
     }
 }

--- a/EventHandlers/HelpDmHandler.cs
+++ b/EventHandlers/HelpDmHandler.cs
@@ -1,9 +1,8 @@
-using System;
 using System.Threading.Tasks;
 using System.Text;
 using System.Text.RegularExpressions;
-using Discord.WebSocket;
 using Reiati.ChillBot.Behavior;
+using Discord;
 
 namespace Reiati.ChillBot.EventHandlers
 {
@@ -41,9 +40,8 @@ namespace Reiati.ChillBot.EventHandlers
         /// <param name="message">The message received.</param>
         /// <param name="handleCache">The match object returned from the regex match.</param>
         /// <returns>The handle task.</returns>
-        protected override async Task HandleMatchedMessage(SocketMessage message, Match handleCache)
+        protected override async Task HandleMatchedMessage(IMessage message, Match handleCache)
         {
-            var messageChannel = message.Channel as SocketDMChannel;
             await message.Channel.SendMessageAsync(HelpDmHandler.HelpMessage);
         }
 

--- a/EventHandlers/HelpGuildHandler.cs
+++ b/EventHandlers/HelpGuildHandler.cs
@@ -1,7 +1,6 @@
 using System.Threading.Tasks;
 using System.Text;
 using System.Text.RegularExpressions;
-using Discord.WebSocket;
 using Reiati.ChillBot.Behavior;
 using Discord;
 
@@ -41,9 +40,9 @@ namespace Reiati.ChillBot.EventHandlers
         /// <param name="message">The message received.</param>
         /// <param name="handleCache">The match object returned from the regex match.</param>
         /// <returns>The handle task.</returns>
-        protected override async Task HandleMatchedMessage(SocketMessage message, Match handleCache)
+        protected override async Task HandleMatchedMessage(IMessage message, Match handleCache)
         {
-            var messageChannel = message.Channel as SocketGuildChannel;
+            var messageChannel = message.Channel as IGuildChannel;
             var messageReference = new MessageReference(message.Id, messageChannel.Id, messageChannel.Guild.Id);
             await message.Channel.SendMessageAsync(HelpGuildHandler.HelpMessage,
                 messageReference: messageReference)

--- a/EventHandlers/IMessageHandler.cs
+++ b/EventHandlers/IMessageHandler.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading.Tasks;
-using Discord.WebSocket;
+using Discord;
 
 namespace Reiati.ChillBot.EventHandlers
 {
@@ -15,7 +15,7 @@ namespace Reiati.ChillBot.EventHandlers
         /// <param name="message">The message received.</param>
         /// <param name="recycleResult">A preallocated result that should be returned if passed in.</param>
         /// <returns>Whether or not this handler can handle the given message.</returns>
-        Task<CanHandleResult> CanHandleMessage(SocketMessage message, CanHandleResult recycleResult = null);
+        Task<CanHandleResult> CanHandleMessage(IMessage message, CanHandleResult recycleResult = null);
 
         /// <summary>
         /// Invoked after this object has been determined to be handleable.
@@ -25,6 +25,6 @@ namespace Reiati.ChillBot.EventHandlers
         /// The same object returned from the earlier call of <see cref="CanHandleMessage"/>.
         /// </param>
         /// <returns>The task to handle the message.</returns>
-        Task HandleMessage(SocketMessage message, object handleCache);
+        Task HandleMessage(IMessage message, object handleCache);
     }
 }

--- a/EventHandlers/JoinOptinGuildHandler.cs
+++ b/EventHandlers/JoinOptinGuildHandler.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using System.Text.RegularExpressions;
 using Discord;
-using Discord.WebSocket;
 using Reiati.ChillBot.Behavior;
 using Reiati.ChillBot.Data;
 using Reiati.ChillBot.Tools;
@@ -69,10 +68,10 @@ namespace Reiati.ChillBot.EventHandlers
         /// <param name="message">The message received.</param>
         /// <param name="handleCache">The match object returned from the regex match.</param>
         /// <returns>The handle task.</returns>
-        protected override async Task HandleMatchedMessage(SocketMessage message, Match handleCache)
+        protected override async Task HandleMatchedMessage(IMessage message, Match handleCache)
         {
-            var messageChannel = message.Channel as SocketGuildChannel;
-            var author = message.Author as SocketGuildUser;
+            var messageChannel = message.Channel as IGuildChannel;
+            var author = message.Author as IGuildUser;
             var guildConnection = messageChannel.Guild;
             var messageReference = new MessageReference(message.Id, messageChannel.Id, guildConnection.Id);
             var channelName = handleCache.Groups["channel"].Captures[0].Value;

--- a/EventHandlers/LeaveOptinDmHandler.cs
+++ b/EventHandlers/LeaveOptinDmHandler.cs
@@ -70,11 +70,11 @@ namespace Reiati.ChillBot.EventHandlers
         /// <param name="message">The message received.</param>
         /// <param name="handleCache">The match object returned from the regex match.</param>
         /// <returns>The handle task.</returns>
-        protected override async Task HandleMatchedMessage(SocketMessage message, Match handleCache)
+        protected override async Task HandleMatchedMessage(IMessage message, Match handleCache)
         {
             var messageChannel = message.Channel as SocketDMChannel;
-            var author = message.Author;
-            var mutualGuilds = message.Author.MutualGuilds;
+            var author = message.Author as SocketUser;
+            var mutualGuilds = author.MutualGuilds;
 
             if (mutualGuilds.Count < 1)
             {

--- a/EventHandlers/ListOptinsGuildHandler.cs
+++ b/EventHandlers/ListOptinsGuildHandler.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Text;
 using System.Text.RegularExpressions;
-using Discord.WebSocket;
 using Reiati.ChillBot.Behavior;
 using Reiati.ChillBot.Data;
 using Reiati.ChillBot.Tools;
@@ -79,9 +78,9 @@ namespace Reiati.ChillBot.EventHandlers
         /// <param name="message">The message received.</param>
         /// <param name="handleCache">The match object returned from the regex match.</param>
         /// <returns>The handle task.</returns>
-        protected override async Task HandleMatchedMessage(SocketMessage message, Match handleCache)
+        protected override async Task HandleMatchedMessage(IMessage message, Match handleCache)
         {
-            var messageChannel = message.Channel as SocketGuildChannel;
+            var messageChannel = message.Channel as IGuildChannel;
             var guildConnection = messageChannel.Guild;
             var messageReference = new MessageReference(message.Id, messageChannel.Id, guildConnection.Id);
 
@@ -141,13 +140,13 @@ namespace Reiati.ChillBot.EventHandlers
         /// <param name="guildConnection">A connection to the guild. May not be null.</param>
         /// <param name="guildData">The guild data. May not be null.</param>
         /// <returns>When listing has completed.</returns>
-        private static async Task ListOptinChannels(SocketMessage message, SocketGuild guildConnection, Guild guildData)
+        private static async Task ListOptinChannels(IMessage message, IGuild guildConnection, Guild guildData)
         {
             var messageReference = new MessageReference(message.Id, message.Channel.Id, guildConnection.Id);
             var listResult = listResultPool.Get();
             try
             {
-                listResult = OptinChannel.List(guildConnection, guildData, listResult);
+                listResult = await OptinChannel.List(guildConnection, guildData, listResult).ConfigureAwait(false);
 
                 switch (listResult.Result)
                 {

--- a/EventHandlers/NewOptinGuildHandler.cs
+++ b/EventHandlers/NewOptinGuildHandler.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using System.Text.RegularExpressions;
 using Discord;
-using Discord.WebSocket;
 using Reiati.ChillBot.Behavior;
 using Reiati.ChillBot.Data;
 using Reiati.ChillBot.Tools;
@@ -78,10 +77,10 @@ namespace Reiati.ChillBot.EventHandlers
         /// <param name="message">The message received.</param>
         /// <param name="handleCache">The match object returned from the regex match.</param>
         /// <returns>The handle task.</returns>
-        protected override async Task HandleMatchedMessage(SocketMessage message, Match handleCache)
+        protected override async Task HandleMatchedMessage(IMessage message, Match handleCache)
         {
-            var messageChannel = message.Channel as SocketGuildChannel;
-            var author = message.Author as SocketGuildUser;
+            var messageChannel = message.Channel as IGuildChannel;
+            var author = message.Author as IGuildUser;
             var guildConnection = messageChannel.Guild;
             var messageReference = new MessageReference(message.Id, messageChannel.Id, guildConnection.Id);
             var channelName = handleCache.Groups[1].Captures[0].Value;

--- a/EventHandlers/RedescribeOptinGuildHandler.cs
+++ b/EventHandlers/RedescribeOptinGuildHandler.cs
@@ -1,5 +1,4 @@
 ﻿using Discord;
-using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
 using Reiati.ChillBot.Behavior;
 using Reiati.ChillBot.Data;
@@ -70,10 +69,10 @@ namespace Reiati.ChillBot.EventHandlers
         /// <param name="message">The message received.</param>
         /// <param name="handleCache">The match object returned from the regex match.</param>
         /// <returns>The handle task.</returns>
-        protected override async Task HandleMatchedMessage(SocketMessage message, Match handleCache)
+        protected override async Task HandleMatchedMessage(IMessage message, Match handleCache)
         {
-            var messageChannel = message.Channel as SocketGuildChannel;
-            var author = message.Author as SocketGuildUser;
+            var messageChannel = message.Channel as IGuildChannel;
+            var author = message.Author as IGuildUser;
             var guildConnection = messageChannel.Guild;
             var messageReference = new MessageReference(message.Id, messageChannel.Id, guildConnection.Id);
             var channelName = handleCache.Groups["channel"].Captures[0].Value;

--- a/EventHandlers/RenameOptinGuildHandler.cs
+++ b/EventHandlers/RenameOptinGuildHandler.cs
@@ -1,5 +1,4 @@
 ﻿using Discord;
-using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
 using Reiati.ChillBot.Behavior;
 using Reiati.ChillBot.Data;
@@ -68,10 +67,10 @@ namespace Reiati.ChillBot.EventHandlers
         /// <param name="message">The message received.</param>
         /// <param name="handleCache">The match object returned from the regex match.</param>
         /// <returns>The handle task.</returns>
-        protected override async Task HandleMatchedMessage(SocketMessage message, Match handleCache)
+        protected override async Task HandleMatchedMessage(IMessage message, Match handleCache)
         {
-            var messageChannel = message.Channel as SocketGuildChannel;
-            var author = message.Author as SocketGuildUser;
+            var messageChannel = message.Channel as IGuildChannel;
+            var author = message.Author as IGuildUser;
             var guildConnection = messageChannel.Guild;
             var messageReference = new MessageReference(message.Id, messageChannel.Id, guildConnection.Id);
             var currentChannelName = handleCache.Groups["currentName"].Captures[0].Value;

--- a/Program.cs
+++ b/Program.cs
@@ -130,6 +130,9 @@ namespace Reiati.ChillBot
                     services.AddSingleton(socketConfig);
                     services.AddSingleton<DiscordShardedClient>();
 
+                    // If the IDiscordClient interface is requested, get the same DiscordShardedClient instance registered above
+                    services.AddSingleton<IDiscordClient>(s => s.GetRequiredService<DiscordShardedClient>());
+
                     // Add services and configuration for the Discord interaction service that handles application commands.
                     var interactionServiceConfig = new InteractionServiceConfig
                     {


### PR DESCRIPTION
Refactor the code to leverage interfaces provided by Discord.Net as much as possible so code is less dependent on the type of `IDiscordClient` used ([socket, sharded, rest](https://discordnet.dev/api/Discord.Rest.BaseDiscordClient.html), etc.).